### PR TITLE
Add support for more input formats to flex.load

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,17 @@ Then in your code.
    schema = flex.load('path/to/schema.yaml')
 
 
+Supported Formats
+-----------------
+
+The ``flex.load`` function supports the following.
+
+- A path to either a ``json`` or ``yaml`` file.
+- A file object whose contents are ``json`` or ``yaml``
+- A string whose contents are ``json`` or ``yaml``
+- A native python object that is a ``Mapping`` (like a dictionary).
+
+
 Contents:
 
 .. toctree::

--- a/tests/core/test_load_source.py
+++ b/tests/core/test_load_source.py
@@ -1,0 +1,81 @@
+import tempfile
+
+import json
+import yaml
+
+from flex.core import load_source
+
+
+def test_native_mapping_is_passthrough():
+    source = {'foo': 'bar'}
+    result = load_source(source)
+
+    assert result == source
+
+
+def test_json_string():
+    native = {'foo': 'bar'}
+    source = json.dumps(native)
+    result = load_source(source)
+
+    assert result == native
+
+
+def test_yaml_string():
+    native = {'foo': 'bar'}
+    source = yaml.dump(native)
+    result = load_source(source)
+
+    assert result == native
+
+
+def test_json_file_object():
+    native = {'foo': 'bar'}
+    source = json.dumps(native)
+
+    tmp_file = tempfile.NamedTemporaryFile(mode='r+w')
+    tmp_file.write(source)
+    tmp_file.file.seek(0)
+
+    result = load_source(tmp_file.file)
+
+    assert result == native
+
+
+def test_json_file_path():
+    native = {'foo': 'bar'}
+    source = json.dumps(native)
+
+    tmp_file = tempfile.NamedTemporaryFile(mode='r+w', suffix='.json')
+    tmp_file.write(source)
+    tmp_file.file.seek(0)
+
+    result = load_source(tmp_file.name)
+
+    assert result == native
+
+
+def test_yaml_file_object():
+    native = {'foo': 'bar'}
+    source = yaml.dump(native)
+
+    tmp_file = tempfile.NamedTemporaryFile(mode='r+w')
+    tmp_file.write(source)
+    tmp_file.file.seek(0)
+
+    result = load_source(tmp_file.file)
+
+    assert result == native
+
+
+def test_yaml_file_path():
+    native = {'foo': 'bar'}
+    source = yaml.dump(native)
+
+    tmp_file = tempfile.NamedTemporaryFile(mode='r+w', suffix='.yaml')
+    tmp_file.write(source)
+    tmp_file.file.seek(0)
+
+    result = load_source(tmp_file.name)
+
+    assert result == native


### PR DESCRIPTION
### What is the problem / feature ?

The `flex.load` function only supported loading a yaml string, or the path to a yaml file.
### How did it get fixed / implemented ?

Added support for:
- json string
- json file path
- json or yaml file object
- native python mapping (like a dictionary)
### How can someone test / see it ?

Code

_Here is a cute animal picture for your troubles..._

![fox and squirrel](https://cloud.githubusercontent.com/assets/824194/4674203/c57b165c-55b1-11e4-8700-c609f0e7ee88.jpg)
