### PR TITLE
add validation for the 'items' keyword

### DIFF
--- a/flex/decorators.py
+++ b/flex/decorators.py
@@ -1,11 +1,8 @@
 import functools
 
-from rest_framework import serializers
-
 from flex.utils import (
     is_non_string_iterable,
-    is_value_of_type,
-    get_type_for_value,
+    is_value_of_any_type,
 )
 from flex.constants import EMPTY
 
@@ -20,17 +17,11 @@ def maybe_iterable(func):
     return inner
 
 
-def enforce_type(type_):
+def skip_if_not_of_type(*types):
     def outer(func):
         @functools.wraps(func)
         def inner(value, *args, **kwargs):
-            if value is EMPTY or is_value_of_type(value, type_):
+            if value is EMPTY or is_value_of_any_type(value, types):
                 return func(value, *args, **kwargs)
-            else:
-                raise serializers.ValidationError(
-                    "Value must be of type {0}.  {1} is of type {2}".format(
-                        type_, value, get_type_for_value(value),
-                    ),
-                )
         return inner
     return outer

--- a/flex/serializers/core.py
+++ b/flex/serializers/core.py
@@ -248,7 +248,9 @@ class SwaggerSerializer(serializers.Serializer):
     Primary Serializer for swagger schema
     """
     swagger = serializers.ChoiceField(
-        choices=[('2.0', '2.0')],
+        choices=[
+            ('2.0', '2.0'),
+        ],
     )
     info = InfoSerializer()
     host = serializers.CharField(

--- a/flex/serializers/definitions.py
+++ b/flex/serializers/definitions.py
@@ -61,7 +61,7 @@ class ItemsSerializer(BaseItemsSerializer):
     def from_native(self, data, files=None):
         if isinstance(data, six.string_types):
             self.context['deferred_references'].add(data)
-            return data
+            return [data]
         return super(ItemsSerializer, self).from_native(data, files)
 
 

--- a/tests/core/test_decorators.py
+++ b/tests/core/test_decorators.py
@@ -1,6 +1,6 @@
 import pytest
 
-from flex.decorators import enforce_type
+from flex.decorators import skip_if_not_of_type
 from flex.constants import (
     NUMBER,
     EMPTY,
@@ -12,11 +12,11 @@ from flex.constants import (
     (0, 1, 2, -2, 0.0, 1.0, 2.0, -2.0),
 )
 def test_type_enforcement_accepts_valid_types(v):
-    @enforce_type(NUMBER)
+    @skip_if_not_of_type(NUMBER)
     def fn(value):
-        pass
+        return True
 
-    fn(v)
+    assert fn(v) is True
 
 
 @pytest.mark.parametrize(
@@ -24,21 +24,8 @@ def test_type_enforcement_accepts_valid_types(v):
     (True, False, '', None, [], {}, 'abcd', ['a'], {'a': 1}),
 )
 def test_type_enforcement_detects_invalid_types(v):
-    from rest_framework import serializers
-
-    @enforce_type(NUMBER)
+    @skip_if_not_of_type(NUMBER)
     def fn(value):
-        pass
+        raise Exception('should not happen')
 
-    with pytest.raises(serializers.ValidationError):
-        fn(v)
-
-
-def test_type_enforcement_skips_empty_value():
-    from rest_framework import serializers
-
-    @enforce_type(NUMBER)
-    def fn(value):
-        pass
-
-    fn(EMPTY)
+    fn(v)

--- a/tests/serializers/common/test_schema_serializer.py
+++ b/tests/serializers/common/test_schema_serializer.py
@@ -275,7 +275,7 @@ def test_max_length_valid_with_string_type():
         OBJECT,
     ),
 )
-def test_max_items_invalid_with_non_arraw_type(type_):
+def test_max_items_invalid_with_non_array_type(type_):
     serializer = BaseSchemaSerializer(
         data={
             'type': type_,

--- a/tests/serializers/definition/test_schema_serializer.py
+++ b/tests/serializers/definition/test_schema_serializer.py
@@ -1,6 +1,17 @@
+import pytest
+
 from flex.serializers.definitions import (
     SchemaSerializer,
+    ItemsSerializer,
 )
+
+from flex.constants import (
+    ARRAY,
+    INTEGER,
+    STRING,
+)
+
+from tests.utils import assert_error_message_equal
 
 
 def test_empty_schema_is_valid():
@@ -29,3 +40,150 @@ def test_schema_item_references_are_deferred():
     )
     assert serializer.is_valid()
     assert 'SomeReference' in serializer.context['deferred_references']
+
+
+#
+# items validation
+#
+@pytest.mark.parametrize(
+    'items',
+    (
+        1234,  # integer
+        1.234,  # number
+        True,  # boolean
+        None,  # null
+    ),
+)
+def test_items_invalid_when_not_array_or_object_or_reference(items):
+    schema = {
+        'type': ARRAY,
+        'items': [items],
+    }
+
+    serializer = SchemaSerializer(
+        data=schema,
+    )
+
+    assert not serializer.is_valid()
+    assert 'items' in serializer.errors
+    assert_error_message_equal(
+        serializer.errors['items'][0],
+        ItemsSerializer.default_error_messages['invalid_type_for_items'],
+    )
+
+
+def test_items_detects_invalid_single_schema():
+    schema = {
+        'type': ARRAY,
+        'items': {
+            'type': INTEGER,
+            'minLength': 4,  # invalid with type 'integer'
+        },
+    }
+
+    serializer = SchemaSerializer(
+        data=schema,
+    )
+
+    assert not serializer.is_valid()
+    assert 'items' in serializer.errors
+    assert 'minLength' in serializer.errors['items'][0]
+    assert_error_message_equal(
+        serializer.errors['items'][0]['minLength'][0],
+        serializer.error_messages['invalid_type_for_min_length'],
+    )
+
+
+def test_items_with_valid_singular_schema():
+    schema = {
+        'type': ARRAY,
+        'items': {
+            'type': INTEGER,
+            'minimum': 4,
+        },
+    }
+
+    serializer = SchemaSerializer(
+        data=schema,
+    )
+
+    assert 'items' not in serializer.errors
+
+
+def test_items_detects_invalid_schema_in_array():
+    schema = {
+        'type': ARRAY,
+        'items': [
+            {
+                'type': INTEGER,
+                'minLength': 4,  # invalid with type 'integer'
+            },
+            {
+                'type': STRING,
+                'minimum': 4,  # invalid with type 'string'
+            },
+        ]
+    }
+
+    serializer = SchemaSerializer(
+        data=schema,
+    )
+
+    assert not serializer.is_valid()
+    assert 'items' in serializer.errors
+    assert 'minLength' in serializer.errors['items'][0]
+    assert_error_message_equal(
+        serializer.errors['items'][0]['minLength'][0],
+        serializer.error_messages['invalid_type_for_min_length'],
+    )
+    assert 'minimum' in serializer.errors['items'][1]
+    assert_error_message_equal(
+        serializer.errors['items'][1]['minimum'][0],
+        serializer.error_messages['invalid_type_for_minimum'],
+    )
+
+
+def test_items_with_array_of_valid_schemas():
+    schema = {
+        'type': ARRAY,
+        'items': [
+            {
+                'type': INTEGER,
+                'minimum': 4,
+            },
+            {
+                'type': STRING,
+                'minLength': 4,
+            },
+        ]
+    }
+
+    serializer = SchemaSerializer(
+        data=schema,
+    )
+
+    assert 'items' not in serializer.errors
+
+
+def test_items_with_mixed_array_of_references_and_schemas():
+    schema = {
+        'type': ARRAY,
+        'items': [
+            {
+                'type': INTEGER,
+                'minimum': 4,
+            },
+            'SomeReference',
+            {
+                'type': STRING,
+                'minLength': 4,
+            },
+        ]
+    }
+
+    serializer = SchemaSerializer(
+        data=schema,
+        context={'deferred_references': set()}
+    )
+
+    assert 'items' not in serializer.errors

--- a/tests/serializers/test_fields.py
+++ b/tests/serializers/test_fields.py
@@ -1,12 +1,14 @@
 import pytest
 
-from rest_framework import serializers
-
 from flex.utils import is_non_string_iterable
 from flex.serializers.fields import (
     MaybeListCharField,
     SecurityRequirementReferenceField,
 )
+
+from django.core.exceptions import ValidationError
+
+from rest_framework import serializers
 
 from tests.utils import assert_error_message_equal
 
@@ -34,15 +36,15 @@ def test_maybe_list_char_field_runs_validators_on_singular_strings():
     def validator(value):
         if is_non_string_iterable(value):
             if not all([v.startswith('bar') for v in value]):
-                raise serializers.ValidationError('error')
+                raise ValidationError('error')
         else:
             if not value.startswith('bar'):
-                raise serializers.ValidationError('error')
+                raise ValidationError('error')
 
     field = MaybeListCharField(validators=[validator])
     data = {'foo': 'not-bar'}
     into = {}
-    with pytest.raises(serializers.ValidationError):
+    with pytest.raises(ValidationError):
         field.field_from_native(data, {}, 'foo', into)
 
 
@@ -50,15 +52,15 @@ def test_maybe_list_char_field_runs_validators_on_lists():
     def validator(value):
         if is_non_string_iterable(value):
             if not all([v.startswith('bar') for v in value]):
-                raise serializers.ValidationError('error')
+                raise ValidationError('error')
         else:
             if not value.startswith('bar'):
-                raise serializers.ValidationError('error')
+                raise ValidationError('error')
 
     field = MaybeListCharField(validators=[validator])
     data = {'foo': ['a-string', 'another-string']}
     into = {}
-    with pytest.raises(serializers.ValidationError):
+    with pytest.raises(ValidationError):
         field.field_from_native(data, {}, 'foo', into)
 
 

--- a/tests/validation/test_items_validation.py
+++ b/tests/validation/test_items_validation.py
@@ -1,0 +1,126 @@
+import pytest
+
+from flex.constants import (
+    ARRAY,
+    INTEGER,
+    STRING,
+)
+
+from tests.utils import generate_validator_from_schema
+
+
+@pytest.mark.parametrize(
+    'items',
+    (
+        [1, 2, 3, 4, -1, -2, 8, 9],  # -1 and -2 are less than minimum
+        [1, 2, 3, 4, 15, 16, 5, 6, 7],  # 15 and 16 are greater than maximum
+        [1, 2, 3, '4', '5', 6],  # string not allowed.
+    )
+)
+def test_invalid_values_against_single_schema(items):
+    from django.core.exceptions import ValidationError
+
+    schema = {
+        'type': ARRAY,
+        'items': {
+            'type': INTEGER,
+            'minimum': 0,
+            'maximum': 10,
+        }
+    }
+
+    validator = generate_validator_from_schema(schema)
+
+    with pytest.raises(ValidationError) as err:
+        validator(items, inner=True)
+
+    assert 'items' in err.value.messages[0]
+    assert len(err.value.messages[0]['items']) == 2
+
+
+@pytest.mark.parametrize(
+    'items',
+    (
+        [1, 2, 3, 4, -1, -2, 8, 9],  # -1 and -2 are less than minimum
+        [1, 2, 3, 4, 15, 16, 5, 6, 7],  # 15 and 16 are greater than maximum
+        [1, 2, 3, '4', '5', 6],  # string not allowed.
+    )
+)
+def test_invalid_values_against_schema_reference(items):
+    from django.core.exceptions import ValidationError
+
+    schema = {
+        'type': ARRAY,
+        'items': 'SomeReference',
+    }
+    context = {
+        'definitions': {
+            'SomeReference': {
+                'type': INTEGER,
+                'minimum': 0,
+                'maximum': 10,
+            },
+        },
+    }
+
+    validator = generate_validator_from_schema(schema, context=context)
+
+    with pytest.raises(ValidationError) as err:
+        validator(items, inner=True)
+
+    assert 'items' in err.value.messages[0]
+    assert len(err.value.messages[0]['items']) == 2
+
+
+def test_invalid_values_against_list_of_schemas():
+    from django.core.exceptions import ValidationError
+
+    schema = {
+        'type': ARRAY,
+        'items': [
+            {'type': INTEGER, 'minimum': 0, 'maximum': 10},
+            {'type': STRING, 'minLength': 3, 'maxLength': 5},
+            {'type': INTEGER, 'minimum': 0, 'maximum': 10},
+            {'type': STRING, 'minLength': 3, 'maxLength': 5},
+            {'type': INTEGER, 'minimum': 0, 'maximum': 10},
+        ],
+    }
+
+    validator = generate_validator_from_schema(schema)
+
+    with pytest.raises(ValidationError) as err:
+        validator(
+            [11, 'abc-abc', -5, 'ab', 'wrong-type'],
+            inner=True,
+        )
+
+    assert 'items' in err.value.messages[0]
+    assert len(err.value.messages[0]['items']) == 5
+    _1, _2, _3, _4, _5 = err.value.messages[0]['items']
+
+    assert 'maximum' in _1
+    assert 'maxLength' in _2
+    assert 'minimum' in _3
+    assert 'minLength' in _4
+    assert 'type' in _5
+
+
+def test_items_past_the_number_of_schemas_provided_are_skipped():
+    from django.core.exceptions import ValidationError
+
+    schema = {
+        'type': ARRAY,
+        'items': [
+            {'type': INTEGER, 'minimum': 0, 'maximum': 10},
+            {'type': INTEGER, 'minimum': 0, 'maximum': 10},
+            {'type': INTEGER, 'minimum': 0, 'maximum': 10},
+        ],
+    }
+
+    validator = generate_validator_from_schema(schema)
+
+    validator(
+        [0, 5, 10, 20, 30, 40],
+        # 20, 30, and 40 don't conform, but are beyond the declared number of schemas.
+        inner=True,
+    )


### PR DESCRIPTION
### What is the problem / feature ?

The `items` schema field was not being validated against.
### How did it get fixed / implemented ?

Added validation for the `items` keyword based on the json schema spec.
### How can someone test / see it ?

Code?

_Here is a cute animal picture for your troubles..._

![663](https://cloud.githubusercontent.com/assets/824194/4776869/0173201c-5bc7-11e4-807b-9ab1aa717b9c.jpg)
