### PR TITLE
Add schema validation to parameter validation

### DIFF
--- a/flex/serializers/core.py
+++ b/flex/serializers/core.py
@@ -39,8 +39,10 @@ from flex.constants import (
     PATH,
     REQUEST_METHODS,
 )
+from flex.validation.common import (
+    validate_object,
+)
 from flex.validation.schema import (
-    validate_schema,
     construct_schema_validators,
 )
 from flex.paths import (
@@ -142,7 +144,7 @@ class SchemaSerializer(BaseSchemaSerializer):
 
     def save_object(self, obj, **kwargs):
         validators = construct_schema_validators(obj, self.context)
-        self.object = functools.partial(validate_schema, validators=validators)
+        self.object = functools.partial(validate_object, validators=validators)
 
 
 class ResponseSerializer(BaseResponseSerializer):

--- a/flex/validation/operation.py
+++ b/flex/validation/operation.py
@@ -80,11 +80,12 @@ def validate_request_parameters(request, validators):
                 errors[key].extend(list(err.messages))
 
 
-def generate_path_parameters_validator(api_path, path_parameters):
+def generate_path_parameters_validator(api_path, path_parameters, context):
     path_parameter_validator = functools.partial(
         validate_path_parameters,
         api_path=api_path,
         path_parameters=path_parameters,
+        context=context,
         inner=True,
     )
     return chain_reduce_partial(
@@ -93,10 +94,11 @@ def generate_path_parameters_validator(api_path, path_parameters):
     )
 
 
-def generate_query_parameters_validator(query_parameters):
+def generate_query_parameters_validator(query_parameters, context):
     query_parameter_validator = functools.partial(
         validate_query_parameters,
         query_parameters=query_parameters,
+        context=context,
         inner=True,
     )
     return chain_reduce_partial(
@@ -105,7 +107,7 @@ def generate_query_parameters_validator(query_parameters):
     )
 
 
-def generate_parameters_validator(api_path, path_definition, parameters, **kwargs):
+def generate_parameters_validator(api_path, path_definition, parameters, context, **kwargs):
     """
     Generates a validator function to validate.
 
@@ -126,11 +128,13 @@ def generate_parameters_validator(api_path, path_definition, parameters, **kwarg
 
     # PATH
     in_path_parameters = filter_parameters(all_parameters, in_=PATH)
-    validators['path'] = generate_path_parameters_validator(api_path, in_path_parameters)
+    validators['path'] = generate_path_parameters_validator(
+        api_path, in_path_parameters, context,
+    )
 
     # QUERY
     in_query_parameters = filter_parameters(all_parameters, in_=QUERY)
-    validators['query'] = generate_query_parameters_validator(in_query_parameters)
+    validators['query'] = generate_query_parameters_validator(in_query_parameters, context)
 
     return chain_reduce_partial(
         operator.attrgetter('request'),

--- a/flex/validation/parameter.py
+++ b/flex/validation/parameter.py
@@ -18,9 +18,60 @@ from flex.validation.common import (
     generate_unique_items_validator,
     generate_pattern_validator,
     generate_enum_validator,
+    validate_object,
+)
+from flex.validation.schema import (
+    construct_schema_validators,
+    generate_items_validator,
 )
 from flex.paths import get_path_parameter_values
 from flex.constants import EMPTY
+
+
+def validate_path_parameters(request_path, api_path, path_parameters, context, inner=False):
+    """
+    Helper function for validating a request path
+    """
+    parameter_values = get_path_parameter_values(request_path, api_path, path_parameters)
+    validate_parameters(parameter_values, path_parameters, context=context, inner=inner)
+
+
+def validate_query_parameters(raw_query_data, query_parameters, context, inner=False):
+    query_data = {}
+    for key, value in raw_query_data.items():
+        if is_non_string_iterable(value) and len(value) == 1:
+            query_data[key] = value[0]
+        else:
+            query_data[key] = value
+    validate_parameters(query_data, query_parameters, context, inner=inner)
+
+
+def validate_parameters(parameter_values, parameters, context, inner=False):
+    validators = construct_multi_parameter_validators(parameters, context=context)
+
+    with ErrorCollection(inner=inner) as errors:
+        # we should have a validator for every parameter value
+        assert not set(parameter_values.keys()).difference(validators.keys())
+
+        for key, validator in validators.items():
+            try:
+                validator(parameter_values.get(key, EMPTY))
+            except ValidationError as err:
+                errors[key].extend(list(err.messages))
+
+
+def construct_parameter_validators(parameter, context):
+    """
+    Constructs a dictionary of validator functions for the provided parameter
+    definition.
+    """
+    validators = {}
+    if 'schema' in parameter:
+        validators.update(construct_schema_validators(parameter['schema'], context=context))
+    for key in parameter:
+        if key in validator_mapping:
+            validators[key] = validator_mapping[key](context=context, **parameter)
+    return validators
 
 
 validator_mapping = {
@@ -37,70 +88,12 @@ validator_mapping = {
     'uniqueItems': generate_unique_items_validator,
     'enum': generate_enum_validator,
     'pattern': generate_pattern_validator,
-    # TODO
-    # - items
-    # - schema
+    'items': generate_items_validator,
 }
 
 
-def validate_path_parameters(request_path, api_path, path_parameters, inner=False):
-    """
-    Helper function for validating a request path
-    """
-    parameter_values = get_path_parameter_values(request_path, api_path, path_parameters)
-    validate_parameters(parameter_values, path_parameters, inner=inner)
-
-
-def validate_query_parameters(raw_query_data, query_parameters, inner=False):
-    query_data = {}
-    for key, value in raw_query_data.items():
-        if is_non_string_iterable(value) and len(value) == 1:
-            query_data[key] = value[0]
-        else:
-            query_data[key] = value
-    validate_parameters(query_data, query_parameters, inner=inner)
-
-
-def validate_parameters(parameter_values, parameters, inner=False):
-    validators = construct_path_parameter_validators(parameters)
-
-    with ErrorCollection(inner=inner) as errors:
-        # we should have a validator for every parameter value
-        assert not set(parameter_values.keys()).difference(validators.keys())
-
-        for key, validator in validators.items():
-            try:
-                validator(parameter_values.get(key, EMPTY))
-            except ValidationError as err:
-                errors[key].extend(list(err.messages))
-
-
-def construct_parameter_validators(parameter):
-    """
-    Constructs a dictionary of validator functions for the provided parameter
-    definition.
-    """
-    validators = {}
-    for key in parameter:
-        if key in validator_mapping:
-            validators[key] = validator_mapping[key](**parameter)
-    return validators
-
-
-def validate_parameter(value, validators, inner=False):
-    """
-    Takes the value for a parameter and applies a dictionary of validator
-    functions, collecting and re-raising any validation erros that occur.
-    """
-    with ErrorCollection(inner=inner) as errors:
-        for key, validator in validators.items():
-            try:
-                validator(value)
-            except ValidationError as err:
-                errors[key].extend(list(err.messages))
-
-
-def construct_path_parameter_validators(parameters):
+# TODO: rename this since it is no longer path specific.
+def construct_multi_parameter_validators(parameters, context):
     """
     Given an iterable of parameters, returns a dictionary of validator
     functions for each parameter.  Note that this expects the parameters to be
@@ -111,9 +104,9 @@ def construct_path_parameter_validators(parameters):
         key = parameter['name']
         if key in validators:
             raise ValueError("Duplicate parameter name {0}".format(key))
-        parameter_validators = construct_parameter_validators(parameter)
+        parameter_validators = construct_parameter_validators(parameter, context=context)
         validators[key] = functools.partial(
-            validate_parameter,
+            validate_object,
             validators=parameter_validators,
             inner=True,
         )

--- a/flex/validation/schema.py
+++ b/flex/validation/schema.py
@@ -12,7 +12,6 @@ from flex.constants import (
     EMPTY,
 )
 from flex.decorators import skip_if_not_of_type
-from flex.context_managers import ErrorCollection
 from flex.validation.common import (
     skip_if_empty,
     generate_type_validator,
@@ -28,6 +27,7 @@ from flex.validation.common import (
     generate_unique_items_validator,
     generate_pattern_validator,
     generate_enum_validator,
+    validate_object,
 )
 
 
@@ -61,50 +61,7 @@ def generate_max_properties_validator(maxProperties, **kwargs):
     return functools.partial(validate_max_properties, maximum=maxProperties)
 
 
-validator_mapping = {
-    'type': generate_type_validator,
-    'multipleOf': generate_multiple_of_validator,
-    'minimum': generate_minimum_validator,
-    'maximum': generate_maximum_validator,
-    'minLength': generate_min_length_validator,
-    'maxLength': generate_max_length_validator,
-    'minItems': generate_min_items_validator,
-    'maxItems': generate_max_items_validator,
-    'uniqueItems': generate_unique_items_validator,
-    'enum': generate_enum_validator,
-    'minProperties': generate_min_properties_validator,
-    'maxProperties': generate_max_properties_validator,
-    'pattern': generate_pattern_validator,
-    'format': generate_format_validator,
-    'required': generate_required_validator,
-}
-
-
-def validate_schema(obj, validators, inner=None):
-    """
-    Given a json-like object to validate, and a dictionary of validators, apply
-    the validators to the object.
-    """
-    with ErrorCollection(inner=inner) as errors:
-        if '$ref' in validators:
-            ref_ = validators.pop('$ref', {})
-            for k, v in ref_.validators.items():
-                validators.setdefault(k, v)
-
-        for key, validator in validators.items():
-            try:
-                validator(obj)
-            except ValidationError as err:
-                errors[key].extend(list(err.messages))
-
-
-def validate_properties(obj, key, validators):
-    if obj is EMPTY:
-        return
-    validate_schema(obj.get(key, EMPTY), validators, inner=True)
-
-
-def generate_items_validators(items, context):
+def construct_items_validators(items, context):
     if isinstance(items, collections.Mapping):
         items_validators = construct_schema_validators(
             items,
@@ -123,12 +80,64 @@ def validate_items(objs, validators):
     errors = []
     for obj, validator in zip(objs, validators):
         try:
-            validate_schema(obj, validator, inner=True)
+            validate_object(obj, validator, inner=True)
         except ValidationError as e:
             errors.extend(list(e.messages))
 
     if errors:
         raise SafeNestedValidationError(errors)
+
+
+def generate_items_validator(items, context, **kwargs):
+    if isinstance(items, collections.Mapping) or isinstance(items, six.string_types):
+        # If items is a reference or a schema, we pass it through as an
+        # ever repeating list of the same validation dictionary, thus
+        # validating all of the objects against the same schema.
+        items_validators = itertools.repeat(construct_items_validators(
+            items,
+            context,
+        ))
+    elif isinstance(items, collections.Sequence):
+        # We generate a list of validator dictionaries and then chain it
+        # with an empty schema that repeats forever.  This ensures that if
+        # the array of objects to be validated is longer than the array of
+        # validators, then the extra elements will always validate since
+        # they will be validated against an empty schema.
+        items_validators = itertools.chain(
+            map(functools.partial(construct_items_validators, context=context), items),
+            itertools.repeat({}),
+        )
+    else:
+        assert "Should not be possible"
+    return functools.partial(
+        validate_items, validators=items_validators,
+    )
+
+
+validator_mapping = {
+    'type': generate_type_validator,
+    'multipleOf': generate_multiple_of_validator,
+    'minimum': generate_minimum_validator,
+    'maximum': generate_maximum_validator,
+    'minLength': generate_min_length_validator,
+    'maxLength': generate_max_length_validator,
+    'minItems': generate_min_items_validator,
+    'maxItems': generate_max_items_validator,
+    'uniqueItems': generate_unique_items_validator,
+    'enum': generate_enum_validator,
+    'minProperties': generate_min_properties_validator,
+    'maxProperties': generate_max_properties_validator,
+    'pattern': generate_pattern_validator,
+    'format': generate_format_validator,
+    'required': generate_required_validator,
+    'items': generate_items_validator,
+}
+
+
+def validate_properties(obj, key, validators):
+    if obj is EMPTY:
+        return
+    validate_object(obj.get(key, EMPTY), validators, inner=True)
 
 
 class LazyReferenceValidator(object):
@@ -147,7 +156,7 @@ class LazyReferenceValidator(object):
         self.context = context
 
     def __call__(self, value):
-        return validate_schema(value, self.validators, inner=True)
+        return validate_object(value, self.validators, inner=True)
 
     @property
     def validators(self):
@@ -175,10 +184,6 @@ def construct_schema_validators(schema, context):
             being validated rather than the object itself.  In this case, we
             need recurse back into this function to generate a dictionary of
             validators for the property.
-        - items:
-            Validating items implies that we are working with an iterable of
-            things to be validated and that we may have to validate each
-            individual array item in some different way.
     """
     validators = {}
     if '$ref' in schema:
@@ -191,42 +196,18 @@ def construct_schema_validators(schema, context):
         intersection = set(schema['properties'].keys()).intersection(schema.keys())
         assert not intersection
 
-        for property, property_schema in schema['properties'].items():
+        for property_, property_schema in schema['properties'].items():
             property_validators = construct_schema_validators(
                 property_schema,
                 context,
             )
-            validators[property] = functools.partial(
+            validators[property_] = functools.partial(
                 validate_properties,
-                key=property,
+                key=property_,
                 validators=property_validators,
             )
-    if 'items' in schema:
-        items = schema['items']
-        if isinstance(items, collections.Mapping) or isinstance(items, six.string_types):
-            # If items is a reference or a schema, we pass it through as an
-            # ever repeating list of the same validation dictionary, thus
-            # validating all of the objects against the same schema.
-            items_validators = itertools.repeat(generate_items_validators(
-                items,
-                context,
-            ))
-        elif isinstance(items, collections.Sequence):
-            # We generate a list of validator dictionaries and then chain it
-            # with an empty schema that repeats forever.  This ensures that if
-            # the array of objects to be validated is longer than the array of
-            # validators, then the extra elements will always validate since
-            # they will be validated against an empty schema.
-            items_validators = itertools.chain(
-                map(functools.partial(generate_items_validators, context=context), items),
-                itertools.repeat({}),
-            )
-        else:
-            assert "Should not be possible"
-        validators['items'] = functools.partial(
-            validate_items, validators=items_validators,
-        )
+    assert 'context' not in schema
     for key in schema:
         if key in validator_mapping:
-            validators[key] = validator_mapping[key](**schema)
+            validators[key] = validator_mapping[key](context=context, **schema)
     return validators

--- a/tests/validation/parameter/test_enum_validation.py
+++ b/tests/validation/parameter/test_enum_validation.py
@@ -53,7 +53,7 @@ def test_enum_validation_with_invalid_values(enum, value):
     }
 
     with pytest.raises(ValidationError) as err:
-        validate_parameters(parameter_values, parameters, inner=True)
+        validate_parameters(parameter_values, parameters, {}, inner=True)
 
     assert 'id' in err.value.messages[0]
     assert 'enum' in err.value.messages[0]['id'][0]
@@ -92,4 +92,4 @@ def test_enum_validation_with_allowed_values(enum, value):
         'id': value,
     }
 
-    validate_parameters(parameter_values, parameters, inner=True)
+    validate_parameters(parameter_values, parameters, {}, inner=True)

--- a/tests/validation/parameter/test_format_validation.py
+++ b/tests/validation/parameter/test_format_validation.py
@@ -43,7 +43,7 @@ def test_parameter_format_validation_on_invalid_values(format_, value, error_key
     }
 
     with pytest.raises(ValidationError) as err:
-        validate_parameters(parameter_values, parameters, inner=True)
+        validate_parameters(parameter_values, parameters, {}, inner=True)
 
     assert 'id' in err.value.messages[0]
     assert 'format' in err.value.messages[0]['id'][0]
@@ -77,4 +77,4 @@ def test_parameter_format_validation_succeeds_on_valid_values(format_, value):
         'id': value,
     }
 
-    validate_parameters(parameter_values, parameters)
+    validate_parameters(parameter_values, parameters, {})

--- a/tests/validation/parameter/test_items_validation.py
+++ b/tests/validation/parameter/test_items_validation.py
@@ -1,0 +1,75 @@
+import pytest
+
+from flex.serializers.core import ParameterSerializer
+from flex.validation.parameter import (
+    validate_parameters,
+)
+from flex.constants import (
+    QUERY,
+    INTEGER,
+    ARRAY,
+)
+from flex.error_messages import MESSAGES
+
+from tests.utils import assert_error_message_equal
+
+
+def test_parameter_items_validation_on_invalid_array():
+    from django.core.exceptions import ValidationError
+    serializer = ParameterSerializer(many=True, data=(
+        {
+            'name': 'id',
+            'in': QUERY,
+            'description': 'id',
+            'items': {
+                'type': INTEGER,
+                'minimum': 0,
+            },
+            'type': ARRAY,
+        },
+    ))
+    assert serializer.is_valid(), serializer.errors
+    parameters = serializer.object
+    value = [1, 2, '3', -1, 4]
+    parameter_values = {
+        'id': value,
+    }
+
+    with pytest.raises(ValidationError) as err:
+        validate_parameters(parameter_values, parameters, context={}, inner=True)
+
+    assert 'id' in err.value.messages[0]
+    assert 'items' in err.value.messages[0]['id'][0]
+    assert 'type' in err.value.messages[0]['id'][0]['items'][0]
+    assert_error_message_equal(
+        err.value.messages[0]['id'][0]['items'][0]['type'][0],
+        MESSAGES['type']['invalid'],
+    )
+    assert 'minimum' in err.value.messages[0]['id'][0]['items'][1]
+    assert_error_message_equal(
+        err.value.messages[0]['id'][0]['items'][1]['minimum'][0],
+        MESSAGES['minimum']['invalid'],
+    )
+
+
+def test_parameter_items_validation_on_valid_value():
+    serializer = ParameterSerializer(many=True, data=(
+        {
+            'name': 'id',
+            'in': QUERY,
+            'description': 'id',
+            'items': {
+                'type': INTEGER,
+                'minimum': 0,
+            },
+            'type': ARRAY,
+        },
+    ))
+    assert serializer.is_valid(), serializer.errors
+    parameters = serializer.object
+    value = [1, 2, 3, 4, 5]
+    parameter_values = {
+        'id': value,
+    }
+
+    validate_parameters(parameter_values, parameters, context={}, inner=True)

--- a/tests/validation/parameter/test_min_max_items_validation.py
+++ b/tests/validation/parameter/test_min_max_items_validation.py
@@ -45,7 +45,7 @@ def test_min_items_on_values_with_too_few_items(min_items, value):
     }
 
     with pytest.raises(ValidationError) as err:
-        validate_parameters(parameter_values, parameters, inner=True)
+        validate_parameters(parameter_values, parameters, {}, inner=True)
 
     assert 'id' in err.value.messages[0]
     assert 'minItems' in err.value.messages[0]['id'][0]
@@ -81,7 +81,7 @@ def test_min_items_on_values_with_valid_array_length(min_items, value):
         'id': value,
     }
 
-    validate_parameters(parameter_values, parameters, inner=True)
+    validate_parameters(parameter_values, parameters, {}, inner=True)
 
 
 #
@@ -115,7 +115,7 @@ def test_max_items_on_values_with_too_many_items(max_items, value):
     }
 
     with pytest.raises(ValidationError) as err:
-        validate_parameters(parameter_values, parameters, inner=True)
+        validate_parameters(parameter_values, parameters, {}, inner=True)
 
     assert 'id' in err.value.messages[0]
     assert 'maxItems' in err.value.messages[0]['id'][0]
@@ -152,4 +152,4 @@ def test_max_items_on_values_with_valid_array_length(max_items, value):
         'id': value,
     }
 
-    validate_parameters(parameter_values, parameters, inner=True)
+    validate_parameters(parameter_values, parameters, {}, inner=True)

--- a/tests/validation/parameter/test_min_max_length_validation.py
+++ b/tests/validation/parameter/test_min_max_length_validation.py
@@ -40,7 +40,7 @@ def test_minimum_length_validation_with_too_short_values(min_length, value):
     }
 
     with pytest.raises(ValidationError) as err:
-        validate_parameters(parameter_values, parameters, inner=True)
+        validate_parameters(parameter_values, parameters, {}, inner=True)
 
     assert 'id' in err.value.messages[0]
     assert 'minLength' in err.value.messages[0]['id'][0]
@@ -73,7 +73,7 @@ def test_minimum_length_validation_with_valid_lengths(min_length, value):
         'id': value,
     }
 
-    validate_parameters(parameter_values, parameters, inner=True)
+    validate_parameters(parameter_values, parameters, {}, inner=True)
 
 
 #
@@ -105,7 +105,7 @@ def test_maximum_length_validation_with_too_long_values(max_length, value):
     }
 
     with pytest.raises(ValidationError) as err:
-        validate_parameters(parameter_values, parameters, inner=True)
+        validate_parameters(parameter_values, parameters, {}, inner=True)
 
     assert 'id' in err.value.messages[0]
     assert 'maxLength' in err.value.messages[0]['id'][0]
@@ -138,4 +138,4 @@ def test_maximum_length_validation_with_valid_lengths(max_length, value):
         'id': value,
     }
 
-    validate_parameters(parameter_values, parameters, inner=True)
+    validate_parameters(parameter_values, parameters, {}, inner=True)

--- a/tests/validation/parameter/test_minimum_and_maximum_validation.py
+++ b/tests/validation/parameter/test_minimum_and_maximum_validation.py
@@ -43,7 +43,7 @@ def test_minimum_validation_for_invalid_values(minimum, value):
     }
 
     with pytest.raises(ValidationError) as err:
-        validate_parameters(parameter_values, parameters, inner=True)
+        validate_parameters(parameter_values, parameters, {}, inner=True)
 
     assert 'id' in err.value.messages[0]
     assert 'minimum' in err.value.messages[0]['id'][0]
@@ -84,7 +84,7 @@ def test_exclusive_minimum_validation_for_invalid_values(minimum, value):
     }
 
     with pytest.raises(ValidationError) as err:
-        validate_parameters(parameter_values, parameters, inner=True)
+        validate_parameters(parameter_values, parameters, {}, inner=True)
 
     assert 'id' in err.value.messages[0]
     assert 'minimum' in err.value.messages[0]['id'][0]
@@ -121,7 +121,7 @@ def test_minimum_validation_for_valid_values(minimum, value):
         'id': value,
     }
 
-    validate_parameters(parameter_values, parameters, inner=True)
+    validate_parameters(parameter_values, parameters, {}, inner=True)
 
 
 @pytest.mark.parametrize(
@@ -150,7 +150,7 @@ def test_exclusive_minimum_validation_for_valid_values(minimum, value):
         'id': value,
     }
 
-    validate_parameters(parameter_values, parameters, inner=True)
+    validate_parameters(parameter_values, parameters, {}, inner=True)
 
 
 #
@@ -183,7 +183,7 @@ def test_maximum_validation_for_invalid_values(maximum, value):
     }
 
     with pytest.raises(ValidationError) as err:
-        validate_parameters(parameter_values, parameters, inner=True)
+        validate_parameters(parameter_values, parameters, {}, inner=True)
 
     assert 'id' in err.value.messages[0]
     assert 'maximum' in err.value.messages[0]['id'][0]
@@ -224,7 +224,7 @@ def test_exclusive_maximum_validation_for_invalid_values(maximum, value):
     }
 
     with pytest.raises(ValidationError) as err:
-        validate_parameters(parameter_values, parameters, inner=True)
+        validate_parameters(parameter_values, parameters, {}, inner=True)
 
     assert 'id' in err.value.messages[0]
     assert 'maximum' in err.value.messages[0]['id'][0]
@@ -261,7 +261,7 @@ def test_maximum_validation_for_valid_values(maximum, value):
         'id': value,
     }
 
-    validate_parameters(parameter_values, parameters, inner=True)
+    validate_parameters(parameter_values, parameters, {}, inner=True)
 
 
 @pytest.mark.parametrize(
@@ -290,4 +290,4 @@ def test_exclusive_maximum_validation_for_valid_values(maximum, value):
         'id': value,
     }
 
-    validate_parameters(parameter_values, parameters, inner=True)
+    validate_parameters(parameter_values, parameters, {}, inner=True)

--- a/tests/validation/parameter/test_multiple_of_validation.py
+++ b/tests/validation/parameter/test_multiple_of_validation.py
@@ -41,7 +41,7 @@ def test_multiple_of_validation_for_invalid_values(divisor, value):
     }
 
     with pytest.raises(ValidationError) as err:
-        validate_parameters(parameter_values, parameters, inner=True)
+        validate_parameters(parameter_values, parameters, {}, inner=True)
 
     assert 'id' in err.value.messages[0]
     assert 'multipleOf' in err.value.messages[0]['id'][0]
@@ -76,4 +76,4 @@ def test_multiple_of_validation_for_valid_multiples(divisor, value):
         'id': value,
     }
 
-    validate_parameters(parameter_values, parameters, inner=True)
+    validate_parameters(parameter_values, parameters, {}, inner=True)

--- a/tests/validation/parameter/test_pattern_validation.py
+++ b/tests/validation/parameter/test_pattern_validation.py
@@ -42,7 +42,7 @@ def test_pattern_validation_with_invalid_values(pattern, value):
     }
 
     with pytest.raises(ValidationError) as err:
-        validate_parameters(parameter_values, parameters, inner=True)
+        validate_parameters(parameter_values, parameters, {}, inner=True)
 
     assert 'id' in err.value.messages[0]
     assert 'pattern' in err.value.messages[0]['id'][0]
@@ -76,4 +76,4 @@ def test_pattern_validation_with_matching_values(pattern, value):
         'id': value,
     }
 
-    validate_parameters(parameter_values, parameters, inner=True)
+    validate_parameters(parameter_values, parameters, {}, inner=True)

--- a/tests/validation/parameter/test_required_validation.py
+++ b/tests/validation/parameter/test_required_validation.py
@@ -24,7 +24,7 @@ def test_required_parameters_invalid_when_not_present():
     parameter_values = {}
 
     with pytest.raises(ValidationError) as err:
-        validate_parameters(parameter_values, parameters, inner=True)
+        validate_parameters(parameter_values, parameters, {}, inner=True)
 
     assert 'id' in err.value.messages[0]
     assert 'required' in err.value.messages[0]['id'][0]
@@ -51,4 +51,4 @@ def test_parameters_allowed_missing_when_not_required():
     parameters = serializer.object
     parameter_values = {}
 
-    validate_parameters(parameter_values, parameters, inner=True)
+    validate_parameters(parameter_values, parameters, {}, inner=True)

--- a/tests/validation/parameter/test_schema_validation.py
+++ b/tests/validation/parameter/test_schema_validation.py
@@ -1,0 +1,146 @@
+import pytest
+
+from flex.serializers.core import ParameterSerializer
+from flex.validation.parameter import (
+    validate_parameters,
+)
+from flex.constants import (
+    BODY,
+    STRING,
+    INTEGER,
+    INT32,
+)
+from flex.error_messages import MESSAGES
+
+from tests.utils import assert_error_message_equal
+
+
+@pytest.mark.parametrize(
+    'value,error_key,message_key',
+    (
+        ('not-a-uuid', 'format', 'invalid_uuid'), # not a valid uuid.
+        (1234, 'type', 'invalid'), # not a string.
+    ),
+)
+def test_parameter_schema_as_reference_validation_for_invalid_value(value, error_key, message_key):
+    from django.core.exceptions import ValidationError
+    context = {
+        'definitions': {'UUID': {'type': STRING, 'format': 'uuid'}},
+    }
+    serializer = ParameterSerializer(many=True, context=context, data=(
+        {
+            'name': 'id',
+            'in': BODY,
+            'description': 'id',
+            'required': True,
+            'schema': {'$ref': 'UUID'},
+        },
+    ))
+    assert serializer.is_valid(), serializer.errors
+    parameters = serializer.object
+    parameter_values = {
+        'id': value,
+    }
+
+    with pytest.raises(ValidationError) as err:
+        validate_parameters(parameter_values, parameters, context=context, inner=True)
+
+    assert 'id' in err.value.messages[0]
+    assert error_key in err.value.messages[0]['id'][0]
+    assert_error_message_equal(
+        err.value.messages[0]['id'][0][error_key][0],
+        MESSAGES[error_key][message_key],
+    )
+
+
+@pytest.mark.parametrize(
+    'value,error_key,message_key',
+    (
+        ('not-a-uuid', 'format', 'invalid_uuid'), # not a valid uuid.
+        (1234, 'type', 'invalid'), # not a string.
+    ),
+)
+def test_parameter_schema_validation_for_invalid_value(value, error_key, message_key):
+    from django.core.exceptions import ValidationError
+    serializer = ParameterSerializer(many=True, data=(
+        {
+            'name': 'id',
+            'in': BODY,
+            'description': 'id',
+            'required': True,
+            'schema': {'type': STRING, 'format': 'uuid'},
+        },
+    ))
+    assert serializer.is_valid(), serializer.errors
+    parameters = serializer.object
+    parameter_values = {
+        'id': value,
+    }
+
+    with pytest.raises(ValidationError) as err:
+        validate_parameters(parameter_values, parameters, context={}, inner=True)
+
+    assert 'id' in err.value.messages[0]
+    assert error_key in err.value.messages[0]['id'][0]
+    assert_error_message_equal(
+        err.value.messages[0]['id'][0][error_key][0],
+        MESSAGES[error_key][message_key],
+    )
+
+
+@pytest.mark.parametrize(
+    'value',
+    (
+        1234,
+        5678,
+    ),
+)
+def test_local_parameter_values_override_schema(value):
+    serializer = ParameterSerializer(many=True, data=(
+        {
+            'name': 'id',
+            'in': BODY,
+            'description': 'id',
+            'required': True,
+            'type': INTEGER,
+            'format': INT32,
+            'schema': {'type': STRING, 'format': 'uuid'},
+        },
+    ))
+    assert serializer.is_valid(), serializer.errors
+    parameters = serializer.object
+    parameter_values = {
+        'id': value,
+    }
+
+    validate_parameters(parameter_values, parameters, context={}, inner=True)
+
+
+@pytest.mark.parametrize(
+    'value',
+    (
+        'http://www.example.com',
+        'http://google.com',
+        'https://facebook.com',
+    ),
+)
+def test_parameter_schema_validation_on_valid_values(value):
+    serializer = ParameterSerializer(many=True, data=(
+        {
+            'name': 'id',
+            'in': BODY,
+            'description': 'id',
+            'required': True,
+            'schema': {
+                'type': STRING,
+                'format': 'uri',
+            },
+        },
+    ))
+    assert serializer.is_valid(), serializer.errors
+    parameters = serializer.object
+    parameter_values = {
+        'id': value,
+    }
+
+    validate_parameters(parameter_values, parameters, context={}, inner=True)

--- a/tests/validation/parameter/test_type_validation.py
+++ b/tests/validation/parameter/test_type_validation.py
@@ -36,7 +36,7 @@ def test_parameter_validation_enforces_type(type_, value):
     }
 
     with pytest.raises(ValidationError) as err:
-        validate_parameters(parameter_values, parameters, inner=True)
+        validate_parameters(parameter_values, parameters, {}, inner=True)
 
     assert 'id' in err.value.messages[0]
     assert 'type' in err.value.messages[0]['id'][0]
@@ -72,4 +72,4 @@ def test_parameter_validation_with_correct_type(type_, value):
         'id': value,
     }
 
-    validate_parameters(parameter_values, parameters, inner=True)
+    validate_parameters(parameter_values, parameters, {}, inner=True)

--- a/tests/validation/parameter/test_unique_items_validation.py
+++ b/tests/validation/parameter/test_unique_items_validation.py
@@ -47,7 +47,7 @@ def test_unique_items_validation_with_duplicates(value):
     }
 
     with pytest.raises(ValidationError) as err:
-        validate_parameters(parameter_values, parameters, inner=True)
+        validate_parameters(parameter_values, parameters, {}, inner=True)
 
     assert 'id' in err.value.messages[0]
     assert 'uniqueItems' in err.value.messages[0]['id'][0]
@@ -84,4 +84,4 @@ def test_unique_items_validation_with_no_duplicates(value):
         'id': value,
     }
 
-    validate_parameters(parameter_values, parameters)
+    validate_parameters(parameter_values, parameters, {})


### PR DESCRIPTION
### What is the problem / feature ?

Parameter validation did not look at `items` or `schema` for validation.
### How did it get fixed / implemented ?

Added validation for both
### How can someone test / see it ?

Do some parameter validation on them.

_Here is a cute animal picture for your troubles..._

![Uploading Brown bear (female) and its children play with a ball in Kamchatka Peninsula, Russia.jpeg . . .]()
