### PR TITLE
Validate that all path parameters in an api_path are present

### DIFF
--- a/flex/error_messages.py
+++ b/flex/error_messages.py
@@ -68,9 +68,9 @@ RESPONSE_MESSAGES = {
 
 PATH_MESSAGES = {
     'missing_parameter': (
-        "The api path `{0}` contains a parameter named `{1}` which does not "
-        "appear in the parameters definitions.  All path parameters must be "
-        "defined"
+        "The parameter named `{0}` is declared to be a PATH parameter but does "
+        "not appear in the api path `{1}`.  All path parameters must exist as a "
+        "parameter in the api path"
     )
 }
 

--- a/flex/parameters.py
+++ b/flex/parameters.py
@@ -1,3 +1,5 @@
+import collections
+
 from flex.decorators import rewrite_reserved_words
 from flex.utils import cast_value_to_type
 
@@ -55,3 +57,10 @@ def merge_parameter_lists(*parameter_definitions):
             key = (parameter['name'], parameter['in'])
             merged_parameters[key] = parameter
     return merged_parameters.values()
+
+
+def dereference_parameter_list(parameters, parameter_definitions):
+    return [
+        (p if isinstance(p, collections.Mapping) else parameter_definitions[p])
+        for p in parameters
+    ]

--- a/flex/paths.py
+++ b/flex/paths.py
@@ -12,6 +12,8 @@ from flex.parameters import (
 
 REGEX_REPLACEMENTS = (
     ('\.', '\.'),
+    ('\{', '\{'),
+    ('\}', '\}'),
 )
 
 
@@ -53,10 +55,13 @@ def process_path_part(part, parameters):
     """
     if PARAMETER_REGEX.match(part):
         parameter_name = part.strip('{}')
-        parameter = find_parameter(parameters, name=parameter_name, in_=PATH)
-        return construct_parameter_pattern(parameter)
-    else:
-        return escape_regex_special_chars(part)
+        try:
+            parameter = find_parameter(parameters, name=parameter_name, in_=PATH)
+        except ValueError:
+            pass
+        else:
+            return construct_parameter_pattern(parameter)
+    return escape_regex_special_chars(part)
 
 
 def get_parameter_names_from_path(api_path):

--- a/flex/serializers/common.py
+++ b/flex/serializers/common.py
@@ -70,9 +70,11 @@ class HomogenousDictSerializer(serializers.Serializer):
                 key for key, value in data.items() if (value is not None or self.allow_empty)
             ]
             for field_name in fields:
+                field = self.value_serializer_class(**self.value_serializer_kwargs)
+                field.initialize(parent=self, field_name=field_name)
                 self.fields.setdefault(
                     field_name,
-                    self.value_serializer_class(**self.value_serializer_kwargs),
+                    field,
                 )
 
     def field_from_native(self, data, files, field_name, into):
@@ -363,14 +365,6 @@ class BaseParameterSerializer(TypedDefaultMixin, CommonJSONSchemaSerializer):
         required=False, validators=[collection_format_validator], default=CSV,
     )
     default = serializers.WritableField(required=False)
-
-    @property
-    def many(self):
-        return True
-
-    @many.setter
-    def many(self, value):
-        pass
 
     def validate(self, attrs):
         errors = collections.defaultdict(list)

--- a/tests/core/test_path_utils.py
+++ b/tests/core/test_path_utils.py
@@ -4,6 +4,7 @@ from flex.serializers.core import ParameterSerializer
 from flex.paths import (
     get_path_parameter_values,
     get_parameter_names_from_path,
+    path_to_pattern,
 )
 from flex.constants import (
     INTEGER,
@@ -57,3 +58,21 @@ def test_getting_names_from_parametrized_path():
     names = get_parameter_names_from_path(path)
     assert len(names) == 3
     assert ("username", "with_underscores", "id") == names
+
+
+#
+# path_to_pattern tests
+#
+def test_undeclared_api_path_parameters_are_skipped():
+    """
+    Test that parameters that are declared in the path string but do not appear
+    in the parameter definitions are ignored.
+    """
+    path = '/get/{username}/posts/{id}/'
+    serializer = ParameterSerializer(many=True, data=[
+        ID_IN_PATH,
+    ])
+    assert serializer.is_valid(), serializer.errors
+    parameters = serializer.object
+    pattern = path_to_pattern(path, parameters)
+    assert pattern == '^/get/\{username\}/posts/(?P<id>.+)/$'

--- a/tests/serializers/common/test_parameter_serializer.py
+++ b/tests/serializers/common/test_parameter_serializer.py
@@ -21,60 +21,60 @@ from tests.utils import assert_error_message_equal
 
 def test_parameter_in_path_but_missing_required():
     serializer = BaseParameterSerializer(
-        data=[{'name': 'test', 'in': PATH}]
+        data={'name': 'test', 'in': PATH}
     )
 
     assert not serializer.is_valid()
-    assert 'required' in serializer.errors[0]
+    assert 'required' in serializer.errors
     assert_error_message_equal(
-        serializer.errors[0]['required'][0],
+        serializer.errors['required'][0],
         serializer.error_messages['path_parameters_are_required'],
     )
 
 
 def test_parameter_in_path_but_declared_not_required():
     serializer = BaseParameterSerializer(
-        data=[{'name': 'test', 'in': PATH, 'required': False}]
+        data={'name': 'test', 'in': PATH, 'required': False}
     )
 
     assert not serializer.is_valid()
-    assert 'required' in serializer.errors[0]
+    assert 'required' in serializer.errors
     assert_error_message_equal(
-        serializer.errors[0]['required'][0],
+        serializer.errors['required'][0],
         serializer.error_messages['path_parameters_are_required'],
     )
 
 
 def test_parameter_in_path_with_required_truthy():
     serializer = BaseParameterSerializer(
-        data=[{'name': 'test', 'in': PATH, 'required': True}]
+        data={'name': 'test', 'in': PATH, 'required': True}
     )
 
-    assert 'required' not in serializer.errors[0]
+    assert 'required' not in serializer.errors
 
 
 def assert_parameter_in_body_with_no_schema():
     serializer = BaseParameterSerializer(
-        data=[{'name': 'test', 'in': BODY}]
+        data={'name': 'test', 'in': BODY}
     )
 
     assert not serializer.is_valid()
-    assert 'schema' in serializer.errors[0]
+    assert 'schema' in serializer.errors
     assert_error_message_equal(
-        serializer.errors[0]['schema'][0],
+        serializer.errors['schema'][0],
         serializer.error_messages['schema_required'],
     )
 
 
 def assert_parameter_in_body_with_no_type():
     serializer = BaseParameterSerializer(
-        data=[{'name': 'test', 'in': BODY}]
+        data={'name': 'test', 'in': BODY}
     )
 
     assert not serializer.is_valid()
-    assert 'type' in serializer.errors[0]
+    assert 'type' in serializer.errors
     assert_error_message_equal(
-        serializer.errors[0]['type'][0],
+        serializer.errors['type'][0],
         serializer.error_messages['type_required'],
     )
 
@@ -88,13 +88,13 @@ def assert_parameter_in_body_with_no_type():
 )
 def test_invalid_in_value_for_multi_collection_format(in_):
     serializer = BaseParameterSerializer(
-        data=[{'name': 'test', 'in': in_, 'collectionFormat': MULTI}]
+        data={'name': 'test', 'in': in_, 'collectionFormat': MULTI}
     )
 
     assert not serializer.is_valid()
-    assert 'collectionFormat' in serializer.errors[0]
+    assert 'collectionFormat' in serializer.errors
     assert_error_message_equal(
-        serializer.errors[0]['collectionFormat'][0],
+        serializer.errors['collectionFormat'][0],
         serializer.error_messages['collection_format_must_be_multi'],
     )
 
@@ -108,10 +108,10 @@ def test_invalid_in_value_for_multi_collection_format(in_):
 )
 def test_valid_in_values_for_multi_collection_format(in_):
     serializer = BaseParameterSerializer(
-        data=[{'name': 'test', 'in': in_, 'collectionFormat': MULTI}]
+        data={'name': 'test', 'in': in_, 'collectionFormat': MULTI}
     )
 
-    assert 'collectionFormat' not in serializer.errors[0]
+    assert 'collectionFormat' not in serializer.errors
 
 
 @pytest.mark.parametrize(
@@ -129,25 +129,25 @@ def test_valid_in_values_for_multi_collection_format(in_):
 )
 def test_mistyped_parameter_default_boolean_to_string(type_, default):
     serializer = BaseParameterSerializer(
-        data=[{'name': 'test', 'in': QUERY, 'type': type_, 'default': default}]
+        data={'name': 'test', 'in': QUERY, 'type': type_, 'default': default}
     )
 
     assert not serializer.is_valid()
-    assert 'default' in serializer.errors[0]
+    assert 'default' in serializer.errors
     assert_error_message_equal(
-        serializer.errors[0]['default'][0],
+        serializer.errors['default'][0],
         serializer.error_messages['default_is_incorrect_type'],
     )
 
 
 def test_items_required_if_type_is_array():
     serializer = BaseParameterSerializer(
-        data=[{'name': 'test', 'in': QUERY, 'type': ARRAY}]
+        data={'name': 'test', 'in': QUERY, 'type': ARRAY}
     )
 
     assert not serializer.is_valid()
-    assert 'items' in serializer.errors[0]
+    assert 'items' in serializer.errors
     assert_error_message_equal(
-        serializer.errors[0]['items'][0],
+        serializer.errors['items'][0],
         serializer.error_messages['items_required'],
     )

--- a/tests/serializers/core/test_paths_serializer.py
+++ b/tests/serializers/core/test_paths_serializer.py
@@ -1,5 +1,9 @@
 from flex.serializers.core import PathsSerializer
 from flex.error_messages import MESSAGES
+from flex.constants import (
+    PATH,
+    INTEGER,
+)
 
 from tests.utils import assert_error_message_equal
 
@@ -19,16 +23,65 @@ def test_paths_serializers_preserves_empty_paths():
     assert '/post' in serializer.object
 
 
-def test_path_serializer_enforces_path_parameters():
+def test_path_serializer_allows_parameters_that_are_not_defined():
     paths = {
         '/get/{id}/': None,
     }
     serializer = PathsSerializer(data=paths)
 
+    assert serializer.is_valid()
+
+
+def test_path_serializer_enforces_all_path_parameters_to_be_in_api_path():
+    paths = {
+        '/get/no-parameters/': {
+            'parameters': [
+                {
+                    'name': 'id',
+                    'in': PATH,
+                    'description': 'id',
+                    'type': INTEGER,
+                    'required': True,
+                },
+            ],
+        }
+    }
+    serializer = PathsSerializer(data=paths)
+
     assert not serializer.is_valid()
     assert 'non_field_errors' in serializer.errors
-    assert '/get/{id}/' in serializer.errors['non_field_errors'][0]
+    assert '/get/no-parameters/' in serializer.errors['non_field_errors'][0]
     assert_error_message_equal(
-        serializer.errors['non_field_errors'][0]['/get/{id}/'][0],
+        serializer.errors['non_field_errors'][0]['/get/no-parameters/'][0],
+        MESSAGES['path']['missing_parameter'],
+    )
+
+
+def test_path_serializer_path_parameter_validation_handles_references():
+    paths = {
+        '/get/no-parameters/': {
+            'parameters': [
+                'Id',
+            ],
+        }
+    }
+    context = {
+        'parameters': {
+            'Id': {
+                'name': 'id',
+                'in': PATH,
+                'description': 'id',
+                'type': INTEGER,
+                'required': True,
+            },
+        }
+    }
+    serializer = PathsSerializer(data=paths, context=context)
+
+    assert not serializer.is_valid()
+    assert 'non_field_errors' in serializer.errors
+    assert '/get/no-parameters/' in serializer.errors['non_field_errors'][0]
+    assert_error_message_equal(
+        serializer.errors['non_field_errors'][0]['/get/no-parameters/'][0],
         MESSAGES['path']['missing_parameter'],
     )

--- a/tests/serializers/definition/test_parameter_definitions.py
+++ b/tests/serializers/definition/test_parameter_definitions.py
@@ -1,0 +1,17 @@
+from flex.serializers.definitions import (
+    ParameterDefinitionsSerializer,
+)
+from flex.constants import (
+    PATH,
+    INTEGER,
+)
+
+
+def test_invalid_list_of_references():
+    data = {
+        'Id': [{'name': 'id', 'in': PATH, 'description': 'id', 'type': INTEGER, 'required': True}],
+    }
+    serializer = ParameterDefinitionsSerializer(
+        data=data,
+    )
+    assert not serializer.is_valid(), serializer.object


### PR DESCRIPTION
### What is the problem / feature ?

API paths that are parametrized need to have all of their parameters declared in the path definitions.  
### How did it get fixed / implemented ?

Added validation for this.
### How can someone test / see it ?

Validate a schema with a path with no parameters in the path, but path parameters defined.

_Here is a cute animal picture for your troubles..._

![funny_cats_in_prear](https://cloud.githubusercontent.com/assets/824194/4912188/a70aef16-6499-11e4-9261-19fc316bfa8c.jpg)
