### PR TITLE
Add support for using a url as the source

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,6 +35,7 @@ Supported Schema Formats
 The ``flex.load`` function supports the following.
 
 - A path to either a ``json`` or ``yaml`` file.
+- A url to either a ``json`` or ``yaml`` file.
 - A file object whose contents are ``json`` or ``yaml``
 - A string whose contents are ``json`` or ``yaml``
 - A native python object that is a ``Mapping`` (like a dictionary).

--- a/flex/core.py
+++ b/flex/core.py
@@ -1,7 +1,9 @@
 from __future__ import unicode_literals
 
+import urlparse
 import os
 import collections
+import requests
 
 import six
 import json
@@ -38,17 +40,21 @@ def load_source(source):
         with open(os.path.expanduser(str(source)), 'r') as source_file:
             raw_source = source_file.read()
     elif isinstance(source, six.string_types):
-        raw_source = source
+        parts = urlparse.urlparse(source)
+        if parts.scheme and parts.netloc:
+            raw_source = requests.get(source).content
+        else:
+            raw_source = source
 
     try:
         try:
-            return yaml.load(raw_source)
-        except yaml.scanner.ScannerError:
+            return json.loads(raw_source)
+        except ValueError:
             pass
 
         try:
-            return json.loads(raw_source)
-        except ValueError:
+            return yaml.load(raw_source)
+        except yaml.scanner.ScannerError:
             pass
     except NameError:
         pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ PyYAML==3.11
 iso8601==0.1.10
 validate-email==1.2
 rfc3987==1.3.4
+requests==2.4.3

--- a/tests/core/test_load_source.py
+++ b/tests/core/test_load_source.py
@@ -1,4 +1,5 @@
 import tempfile
+import collections
 
 import json
 import yaml
@@ -78,4 +79,26 @@ def test_yaml_file_path():
 
     result = load_source(tmp_file.name)
 
+    assert result == native
+
+
+def test_url(httpbin):
+    native = {
+        'origin': '127.0.0.1',
+        #'headers': {
+        #    'Content-Length': '',
+        #    'Accept-Encoding': 'gzip, deflate',
+        #    'Host': '127.0.0.1:54634',
+        #    'Accept': '*/*',
+        #    'User-Agent': 'python-requests/2.4.3 CPython/2.7.8 Darwin/14.0.0',
+        #    'Connection': 'keep-alive',
+        #},
+        'args': {},
+        #'url': 'http://127.0.0.1:54634/get',
+    }
+    source = httpbin.url + '/get'
+    result = load_source(source)
+    assert isinstance(result, collections.Mapping)
+    result.pop('headers')
+    result.pop('url')
     assert result == native


### PR DESCRIPTION
### What is the problem / feature ?

It'd be nice to be able to use `flex.core.load` with the url of a swagger schema.
### How did it get fixed / implemented ?

Added support for using a url.
### How can someone test / see it ?

Pass a url into the function and see that you get back the parsed and validated swagger schema.

_Here is a cute animal picture for your troubles..._

![raccoon_cute_pose](https://cloud.githubusercontent.com/assets/824194/4913179/f8309410-64ab-11e4-99b8-ca40549490b0.jpg)
