### PR TITLE
Add response body validation

### DIFF
--- a/flex/constants.py
+++ b/flex/constants.py
@@ -37,10 +37,10 @@ PRIMATIVE_TYPES = {
 
 HEADER_TYPES = (
     STRING,
+    INTEGER,
     NUMBER,
     BOOLEAN,
     ARRAY,
-    OBJECT,
 )
 
 

--- a/flex/error_messages.py
+++ b/flex/error_messages.py
@@ -1,5 +1,9 @@
 TYPE_MESSAGES = {
     'invalid': "Got value `{0}` of type `{1}`.  Value must be of type(s): `{2}`",
+    'invalid_header_type': (
+        "Invalid type for header: `{0}`.  Must be one of 'string', 'number', "
+        "'integer', 'boolean', or 'array'."
+    ),
 }
 
 FORMAT_MESSAGES = {

--- a/flex/http.py
+++ b/flex/http.py
@@ -39,6 +39,9 @@ def normalize_request(request):
     """
     Given a request, normalize it to the internal Request class.
     """
+    if isinstance(request, Request):
+        return request
+
     url = request.url
     method = request.method.lower()
     content_type = request.headers.get('Content-Type')
@@ -59,7 +62,8 @@ class Response(URLMixin):
     _response = None
     status_code = None
 
-    def __init__(self, request, content, url, status_code, content_type, response=None):
+    def __init__(self, request, content, url, status_code, content_type,
+                 response=None):
         self._response = response
         self.request = request
         self.content = content
@@ -73,8 +77,9 @@ class Response(URLMixin):
 
     @property
     def data(self):
-        # TODO: content negotiation
-        return json.loads(self.content)
+        if self.content_type == 'application/json':
+            return json.loads(self.content)
+        raise NotImplementedError("No content negotiation for this content type")
 
 
 def normalize_response(response):
@@ -82,6 +87,8 @@ def normalize_response(response):
     Given a response, normalize it to the internal Response class.  This also
     involves normalizing the associated request object.
     """
+    if isinstance(response, Response):
+        return response
     request = normalize_request(response.request)
 
     url = response.url

--- a/flex/serializers/core.py
+++ b/flex/serializers/core.py
@@ -22,6 +22,7 @@ from flex.serializers.common import (
     BaseParameterSerializer,
     BaseSchemaSerializer,
     BaseItemsSerializer,
+    BaseHeaderSerializer,
 )
 from flex.serializers.validators import (
     host_validator,
@@ -29,7 +30,6 @@ from flex.serializers.validators import (
     scheme_validator,
     mimetype_validator,
     string_type_validator,
-    header_type_validator,
     format_validator,
     collection_format_validator,
 )
@@ -84,36 +84,8 @@ class ItemsSerializer(BaseItemsSerializer):
         return super(ItemsSerializer, self).from_native(data, files)
 
 
-class HeaderSerializer(TypedDefaultMixin, CommonJSONSchemaSerializer):
-    """
-    https://github.com/wordnik/swagger-spec/blob/master/versions/2.0.md#header-object-
-    """
-    default_error_messages = {
-        'items_required': (
-            "When type is \"array\" the \"items\" is required"
-        ),
-    }
-    description = serializers.CharField(required=False)
-    type = serializers.CharField(validators=[header_type_validator])
-    format = serializers.CharField(validators=[format_validator], required=False)
+class HeaderSerializer(BaseHeaderSerializer):
     items = ItemsSerializer(required=False, many=True)
-    collectionFormat = serializers.CharField(
-        required=False, validators=[collection_format_validator], default=CSV,
-    )
-    default = serializers.WritableField(required=False)
-
-    def validate(self, attrs):
-        errors = collections.defaultdict(list)
-
-        if attrs.get('type') == ARRAY and 'items' not in attrs:
-            errors['items'].append(
-                self.error_messages['items_required'],
-            )
-        self.validate_default_type(attrs, errors)
-
-        if errors:
-            raise serializers.ValidationError(errors)
-        return super(HeaderSerializer, self).validate(attrs)
 
 
 class HeadersSerializer(HomogenousDictSerializer):
@@ -151,7 +123,6 @@ class ResponseSerializer(BaseResponseSerializer):
     """
     https://github.com/wordnik/swagger-spec/blob/master/versions/2.0.md#responseObject
     """
-    description = serializers.CharField()
     schema = SchemaSerializer(required=False)
     headers = HeadersSerializer(required=False)
     # TODO: how do we do examples

--- a/flex/serializers/validators.py
+++ b/flex/serializers/validators.py
@@ -24,6 +24,7 @@ from flex.constants import (
     SECURITY_FLOWS,
     ARRAY,
 )
+from flex.error_messages import MESSAGES
 
 
 def host_validator(value):
@@ -103,7 +104,7 @@ def type_validator(value):
 def header_type_validator(value):
     if value not in HEADER_TYPES:
         raise serializers.ValidationError(
-            "Unknown type for header: `{0}`".format(value),
+            MESSAGES['type']['invalid_header_type'].format(value),
         )
 
 

--- a/tests/core/test_request_response_objects.py
+++ b/tests/core/test_request_response_objects.py
@@ -1,7 +1,4 @@
-from flex.http import (
-    Request,
-    Response,
-)
+import json
 
 from tests.factories import (
     RequestFactory,
@@ -29,3 +26,15 @@ def test_query_data_for_multi_value_keys():
         url='http://www.example.com/api/?token=1234&token=5678&secret=abcd',
     )
     assert request.query_data == {'token': ['1234', '5678'], 'secret': ['abcd']}
+
+
+def test_response_factory_propogates_url_to_request():
+    response = ResponseFactory(url='http://www.example.com/should-propogate-up/')
+    assert response.url == response.request.url
+
+
+def test_response_data_as_json():
+    expected = {'foo': '1234'}
+    response = ResponseFactory(content=json.dumps(expected))
+
+    assert response.data == expected

--- a/tests/serializers/common/test_header_serializer.py
+++ b/tests/serializers/common/test_header_serializer.py
@@ -1,0 +1,22 @@
+from flex.serializers.core import (
+    HeaderSerializer,
+)
+from flex.constants import (
+    OBJECT,
+)
+from flex.error_messages import MESSAGES
+
+from tests.utils import assert_error_message_equal
+
+
+def test_header_type_cannot_be_object():
+    serializer = HeaderSerializer(
+        data={'type': OBJECT},
+    )
+
+    assert not serializer.is_valid()
+    assert 'type' in serializer.errors
+    assert_error_message_equal(
+        serializer.errors['type'][0],
+        MESSAGES['type']['invalid_header_type'],
+    )

--- a/tests/serializers/definition/test_response_definitions.py
+++ b/tests/serializers/definition/test_response_definitions.py
@@ -1,0 +1,28 @@
+from flex.serializers.definitions import (
+    HeaderSerializer,
+)
+
+from flex.constants import (
+    ARRAY,
+    INTEGER,
+)
+
+
+def test_schema_reference_is_placed_in_deferred_refrences():
+    context = {'deferred_references': set()}
+    serializer = HeaderSerializer(
+        data={'type': INTEGER, 'schema': 'SomeReference'},
+        context=context,
+    )
+    assert serializer.is_valid(), serializer.errors
+    assert 'SomeReference' in serializer.context['deferred_references']
+
+
+def test_schema_item_references_are_deferred():
+    context = {'deferred_references': set()}
+    serializer = HeaderSerializer(
+        data={'type': ARRAY, 'items': ['SomeReference']},
+        context=context,
+    )
+    assert serializer.is_valid(), serializer.errors
+    assert 'SomeReference' in serializer.context['deferred_references']

--- a/tests/validation/response/test_schema_validation.py
+++ b/tests/validation/response/test_schema_validation.py
@@ -1,0 +1,52 @@
+import json
+import pytest
+
+from flex.constants import (
+    INTEGER,
+)
+from flex.validation.response import (
+    generate_response_validator,
+)
+from flex.error_messages import MESSAGES
+
+from tests.factories import (
+    SchemaFactory,
+    ResponseFactory,
+)
+from tests.utils import assert_error_message_equal
+
+
+def test_basic_response_body_schema_validation_with_invalid_value():
+    from django.core.exceptions import ValidationError
+    schema = SchemaFactory(
+        paths={
+            '/get': {
+                'get': {
+                    'responses': {
+                        200: {
+                            'description': 'Success',
+                            'schema': {'type': INTEGER},
+                        }
+                    },
+                },
+            },
+        },
+    )
+    response_validator = generate_response_validator(schema, inner=True)
+
+    response = ResponseFactory(
+        url='http://www.example.com/get',
+        status_code=200,
+        content_type='application/json',
+        content=json.dumps('not-an-integer'),
+    )
+
+    with pytest.raises(ValidationError) as err:
+        response_validator(response)
+
+    assert 'response_body' in err.value.messages[0]
+    assert 'type' in err.value.messages[0]['response_body'][0]
+    assert_error_message_equal(
+        err.value.messages[0]['response_body'][0]['type'][0],
+        MESSAGES['type']['invalid'],
+    )


### PR DESCRIPTION
### What is the problem / feature ?

It'd be good if response validation actually looked at the response body.  (it currently doesn't)
### How did it get fixed / implemented ?

Implemented a `data` property on the `flex.http.Response` object to represent the response data, and added validation against it.
### How can someone test / see it ?

Validate a response?

_Here is a cute animal picture for your troubles..._

![sun-bear1](https://cloud.githubusercontent.com/assets/824194/4962918/7941fe28-66ef-11e4-8259-16ba4f72cc8a.jpg)
