### PR TITLE
Fixes #12 Implement response header validation

### DIFF
--- a/flex/constants.py
+++ b/flex/constants.py
@@ -35,6 +35,9 @@ PRIMATIVE_TYPES = {
     OBJECT: (collections.Mapping,),
 }
 
+TRUE_VALUES = set(('true', 'True', '1'))
+FALSE_VALUES = set(('false', 'False', '0', ''))
+
 HEADER_TYPES = (
     STRING,
     INTEGER,
@@ -60,14 +63,24 @@ PARAMETER_IN_VALUES = (
 
 CSV = 'csv'
 MULTI = 'multi'
+SSV = 'ssv'
+TSV = 'tsv'
+PIPES = 'pipes'
 
 COLLECTION_FORMATS = (
     CSV,
-    'ssv',
-    'tsv',
-    'pipes',
+    SSV,
+    TSV,
+    PIPES,
     MULTI,
 )
+
+DELIMETERS = {
+    CSV: ',',
+    SSV: ' ',
+    TSV: '\t',
+    PIPES: '|',
+}
 
 
 API_KEY = 'apiKey'

--- a/flex/http.py
+++ b/flex/http.py
@@ -66,13 +66,14 @@ class Response(URLMixin):
     status_code = None
 
     def __init__(self, request, content, url, status_code, content_type,
-                 response=None):
+                 headers=None, response=None):
         self._response = response
         self.request = request
         self.content = content
         self.url = url
         self.status_code = status_code
         self.content_type = content_type
+        self.headers = headers or {}
 
     @property
     def path(self):

--- a/flex/parameters.py
+++ b/flex/parameters.py
@@ -1,7 +1,6 @@
 import collections
 
 from flex.decorators import rewrite_reserved_words
-from flex.utils import cast_value_to_type
 
 
 @rewrite_reserved_words
@@ -30,20 +29,6 @@ def find_parameter(parameters, **kwargs):
     elif len(matching_parameters) > 1:
         raise ValueError("More than 1 parameter matched")
     raise ValueError("No parameters matched")
-
-
-def type_cast_parameters(parameter_values, parameter_definitions):
-    typed_parameters = {}
-    for key in parameter_values.keys():
-        try:
-            parameter_definition = find_parameter(parameter_definitions, name=key)
-        except KeyError:
-            continue
-        if 'type' not in parameter_definition:
-            continue
-        value = parameter_values[key]
-        typed_parameters[key] = cast_value_to_type(value, parameter_definition['type'])
-    return typed_parameters
 
 
 def merge_parameter_lists(*parameter_definitions):

--- a/flex/paths.py
+++ b/flex/paths.py
@@ -6,7 +6,6 @@ from flex.constants import (
 )
 from flex.parameters import (
     find_parameter,
-    type_cast_parameters,
 )
 
 
@@ -116,11 +115,3 @@ def match_request_path_to_api_path(path_definitions, request_path, base_path='')
         ))
     else:
         return matches[0]
-
-
-def get_path_parameter_values(request_path, api_path, path_parameters):
-    raw_values = path_to_regex(
-        api_path,
-        path_parameters,
-    ).match(request_path).groupdict()
-    return type_cast_parameters(raw_values, path_parameters)

--- a/flex/utils.py
+++ b/flex/utils.py
@@ -14,6 +14,8 @@ from flex.constants import (
     STRING,
     ARRAY,
     OBJECT,
+    TRUE_VALUES,
+    FALSE_VALUES,
 )
 
 
@@ -42,13 +44,21 @@ def cast_value_to_type(value, type_):
     if type_ == STRING:
         return six.text_type(value)
     elif type_ == INTEGER:
-        return int(float(value))
+        return int(value)
     elif type_ == NUMBER:
         return float(value)
     elif type_ == ARRAY:
         return list(value)
     elif type_ == OBJECT:
         return dict(value)
+    elif type_ == BOOLEAN:
+        if value in TRUE_VALUES:
+            return True
+        elif value in FALSE_VALUES:
+            return False
+        else:
+            raise TypeError("Invalid value for boolean: `{0}`".format(repr(value)))
+    # TODO: the only thing left is null type.
     return PRIMATIVE_TYPES[type_][0](value)
 
 

--- a/tests/core/test_path_utils.py
+++ b/tests/core/test_path_utils.py
@@ -1,8 +1,5 @@
-import six
-
 from flex.serializers.core import ParameterSerializer
 from flex.paths import (
-    get_path_parameter_values,
     get_parameter_names_from_path,
     path_to_pattern,
 )
@@ -19,29 +16,6 @@ ID_IN_PATH = {
 USERNAME_IN_PATH = {
     'name': 'username', 'in': PATH, 'description': 'username', 'type': STRING, 'required': True
 }
-
-
-#
-#  get_path_parameter_values tests
-#
-def test_getting_parameter_values_from_path():
-    serializer = ParameterSerializer(many=True, data=[
-        ID_IN_PATH,
-        USERNAME_IN_PATH,
-    ])
-    assert serializer.is_valid(), serializer.errors
-    parameters = serializer.object
-
-    values = get_path_parameter_values(
-        request_path='/get/fernando/posts/1234/',
-        api_path='/get/{username}/posts/{id}/',
-        path_parameters=parameters
-    )
-    assert len(values) == 2
-    assert 'username' in values
-    assert 'id' in values
-    assert isinstance(values['username'], six.string_types)
-    assert isinstance(values['id'], int)
 
 
 #

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -289,7 +289,6 @@ def test_get_type_for_object(value):
     (
         ('5', NUMBER, 5),
         ('8', INTEGER, 8),
-        ('1.6', INTEGER, 1),
         ('2.3', NUMBER, 2.3),
         (15, STRING, '15'),
         (12.5, STRING, '12.5'),
@@ -297,12 +296,15 @@ def test_get_type_for_object(value):
         (True, STRING, 'True'),
         (False, NUMBER, 0),
         (False, STRING, 'False'),
-        ('0', BOOLEAN, True),
-        (0, BOOLEAN, False),
+        ('1', BOOLEAN, True),
+        ('true', BOOLEAN, True),
+        ('True', BOOLEAN, True),
         ('', BOOLEAN, False),
+        ('false', BOOLEAN, False),
+        ('False', BOOLEAN, False),
+        ('0', BOOLEAN, False),
         ('abc', ARRAY, ['a', 'b', 'c']),
         (collections.OrderedDict((('a', 1), ('b', 2))), ARRAY, ['a', 'b']),
-        ([], BOOLEAN, False),
     )
 )
 def test_casting_appropriate_values_to_type(value, type_, expected):
@@ -315,6 +317,7 @@ def test_casting_appropriate_values_to_type(value, type_, expected):
         ([], NUMBER),
         ('abc', NUMBER),
         (1, NULL),
+        ('1.6', INTEGER),
         ('abc', NULL),
         ([], NULL),
         ({}, NULL),

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -26,6 +26,7 @@ class ResponseFactory(factory.Factory):
     content_type = 'application/json'
     content = EMPTY
     status_code = 200
+    headers = factory.Dict({})
 
     request = factory.SubFactory(
         RequestFactory, url=factory.SelfAttribute('..url'),

--- a/tests/validation/headers/test_header_type_casting.py
+++ b/tests/validation/headers/test_header_type_casting.py
@@ -1,0 +1,163 @@
+import pytest
+
+from flex.serializers.core import HeaderSerializer
+from flex.validation.common import generate_value_processor
+from flex.constants import (
+    INTEGER,
+    NUMBER,
+    BOOLEAN,
+    ARRAY,
+    STRING,
+    CSV,
+    SSV,
+    TSV,
+    PIPES,
+)
+
+
+def test_integer_header_type():
+    serializer = HeaderSerializer(
+        data={
+            'type': INTEGER,
+        }
+    )
+    assert serializer.is_valid(), serializer.errors
+    value_processor = generate_value_processor(context={}, **serializer.object)
+
+    actual = value_processor('123')
+    expected = 123
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    'value',
+    (
+        '1.2', # Non integer
+        'abc', # Non number
+    )
+)
+def test_integer_header_type_with_invalid_values(value):
+    serializer = HeaderSerializer(
+        data={
+            'type': INTEGER,
+        }
+    )
+    assert serializer.is_valid(), serializer.errors
+    value_processor = generate_value_processor(context={}, **serializer.object)
+
+    actual = value_processor(value)
+    assert actual == value
+
+
+def test_number_header_type():
+    serializer = HeaderSerializer(
+        data={
+            'type': NUMBER,
+        }
+    )
+    assert serializer.is_valid(), serializer.errors
+    value_processor = generate_value_processor(context={}, **serializer.object)
+
+    actual = value_processor('10.5')
+    expected = 10.5
+    assert actual == expected
+
+
+def test_number_header_type_with_invalid_value():
+    serializer = HeaderSerializer(
+        data={
+            'type': NUMBER,
+        }
+    )
+    assert serializer.is_valid(), serializer.errors
+    value_processor = generate_value_processor(context={}, **serializer.object)
+
+    actual = value_processor('abc')
+    assert actual == 'abc'
+
+
+@pytest.mark.parametrize(
+    'input_,expected',
+    (
+        ('true', True),
+        ('True', True),
+        ('false', False),
+        ('False', False),
+        ('1', True),
+        ('0', False),
+        ('', False),
+    )
+)
+def test_boolean_header_type(input_, expected):
+    serializer = HeaderSerializer(
+        data={
+            'type': BOOLEAN,
+        }
+    )
+    assert serializer.is_valid(), serializer.errors
+    value_processor = generate_value_processor(context={}, **serializer.object)
+
+    actual = value_processor(input_)
+    assert actual == expected
+
+
+def test_boolean_header_type_for_invalid_value():
+    serializer = HeaderSerializer(
+        data={
+            'type': BOOLEAN,
+        }
+    )
+    assert serializer.is_valid(), serializer.errors
+    value_processor = generate_value_processor(context={}, **serializer.object)
+
+    actual = value_processor('not-a-known-boolean')
+    assert actual == 'not-a-known-boolean'
+
+
+@pytest.mark.parametrize(
+    'format_,input_',
+    (
+        (CSV, '1,2,3'),
+        (CSV, '1, 2, 3'),
+        (SSV, '1 2 3'),
+        (SSV, '1 2  3'),
+        (TSV, '1\t2\t3'),
+        (TSV, '1\t 2\t 3'),
+        (PIPES, '1|2|3'),
+        (PIPES, '1| 2| 3'),
+    )
+)
+def test_array_header_type_casting_with_single_tems(format_, input_):
+    serializer = HeaderSerializer(
+        data={
+            'type': ARRAY,
+            'collectionFormat': format_,
+            'items': {'type': INTEGER}
+        }
+    )
+    assert serializer.is_valid(), serializer.errors
+    value_processor = generate_value_processor(context={}, **serializer.object)
+
+    actual = value_processor(input_)
+    expected = [1, 2, 3]
+    assert actual == expected
+
+
+def test_array_header_type_casting_with_multiple_items():
+    serializer = HeaderSerializer(
+        data={
+            'type': ARRAY,
+            'collectionFormat': CSV,
+            'items': [
+                {'type': INTEGER},
+                {'type': STRING},
+                {'type': BOOLEAN},
+            ]
+        }
+    )
+    assert serializer.is_valid(), serializer.errors
+    value_processor = generate_value_processor(context={}, **serializer.object)
+
+    actual = value_processor('1,a,true,2')
+    expected = [1, 'a', True, '2']
+    assert actual == expected

--- a/tests/validation/parameter/test_parameter_type_casting.py
+++ b/tests/validation/parameter/test_parameter_type_casting.py
@@ -1,0 +1,99 @@
+import pytest
+
+from flex.serializers.core import ParameterSerializer
+from flex.constants import (
+    INTEGER,
+    NUMBER,
+    BOOLEAN,
+    ARRAY,
+    QUERY,
+    CSV,
+    SSV,
+    TSV,
+    PIPES,
+)
+from flex.validation.parameter import (
+    type_cast_parameters,
+)
+
+
+#
+# type_cast_parameters tests
+#
+def test_integer_type_casting():
+    serializer = ParameterSerializer(data=[{
+        'type': INTEGER,
+        'in': QUERY,
+        'description': 'id',
+        'name': 'id',
+    }])
+    assert serializer.is_valid(), serializer.errors
+    parameters = {'id': '123'}
+    actual = type_cast_parameters(parameters, serializer.object, {})
+    assert actual['id'] == 123
+
+
+def test_number_type_casting():
+    serializer = ParameterSerializer(data=[{
+        'type': NUMBER,
+        'in': QUERY,
+        'description': 'id',
+        'name': 'id',
+    }])
+    assert serializer.is_valid(), serializer.errors
+    parameters = {'id': '12.5'}
+    actual = type_cast_parameters(parameters, serializer.object, {})
+    assert actual['id'] == 12.5
+
+
+@pytest.mark.parametrize(
+    'input_,expected',
+    (
+        ('true', True),
+        ('True', True),
+        ('1', True),
+        ('false', False),
+        ('False', False),
+        ('0', False),
+        ('', False),
+    )
+)
+def test_boolean_type_casting(input_, expected):
+    serializer = ParameterSerializer(data=[{
+        'type': BOOLEAN,
+        'in': QUERY,
+        'description': 'id',
+        'name': 'id',
+    }])
+    assert serializer.is_valid(), serializer.errors
+    parameters = {'id': input_}
+    actual = type_cast_parameters(parameters, serializer.object, {})
+    assert actual['id'] == expected
+
+
+@pytest.mark.parametrize(
+    'format_,value',
+    (
+        (CSV, '1,2,3'),
+        (CSV, '1, 2, 3'),
+        (SSV, '1 2 3'),
+        (SSV, '1 2  3'),
+        (TSV, '1\t2\t3'),
+        (TSV, '1\t 2\t 3'),
+        (PIPES, '1|2|3'),
+        (PIPES, '1| 2| 3'),
+    )
+)
+def test_array_type_casting(format_, value):
+    serializer = ParameterSerializer(data=[{
+        'type': ARRAY,
+        'collectionFormat': format_,
+        'in': QUERY,
+        'description': 'id',
+        'name': 'id',
+        'items': {'type': INTEGER},
+    }])
+    assert serializer.is_valid(), serializer.errors
+    parameters = {'id': value}
+    actual = type_cast_parameters(parameters, serializer.object, {})
+    assert actual['id'] == [1, 2, 3]

--- a/tests/validation/parameter/test_path_parameter_extraction.py
+++ b/tests/validation/parameter/test_path_parameter_extraction.py
@@ -1,0 +1,43 @@
+import six
+
+from flex.serializers.core import ParameterSerializer
+from flex.validation.parameter import (
+    get_path_parameter_values,
+)
+from flex.constants import (
+    INTEGER,
+    STRING,
+    PATH,
+)
+
+
+ID_IN_PATH = {
+    'name': 'id', 'in': PATH, 'description': 'id', 'type': INTEGER, 'required': True,
+}
+USERNAME_IN_PATH = {
+    'name': 'username', 'in': PATH, 'description': 'username', 'type': STRING, 'required': True
+}
+
+
+#
+#  get_path_parameter_values tests
+#
+def test_getting_parameter_values_from_path():
+    serializer = ParameterSerializer(many=True, data=[
+        ID_IN_PATH,
+        USERNAME_IN_PATH,
+    ])
+    assert serializer.is_valid(), serializer.errors
+    parameters = serializer.object
+
+    values = get_path_parameter_values(
+        request_path='/get/fernando/posts/1234/',
+        api_path='/get/{username}/posts/{id}/',
+        path_parameters=parameters,
+        context={},
+    )
+    assert len(values) == 2
+    assert 'username' in values
+    assert 'id' in values
+    assert isinstance(values['username'], six.string_types)
+    assert isinstance(values['id'], int)

--- a/tests/validation/response/test_request_header_validation.py
+++ b/tests/validation/response/test_request_header_validation.py
@@ -1,13 +1,17 @@
 import pytest
 
 from flex.validation.response import (
-    validate_response,
+    validate_api_call,
 )
 from flex.error_messages import MESSAGES
 from flex.constants import (
     INTEGER,
-    UUID,
     HEADER,
+    ARRAY,
+    CSV,
+    SSV,
+    TSV,
+    PIPES,
 )
 
 from tests.factories import (
@@ -43,7 +47,7 @@ def test_request_header_validation():
     )
 
     with pytest.raises(ValidationError) as err:
-        validate_response(
+        validate_api_call(
             response,
             paths=schema['paths'],
             base_path=schema.get('base_path', ''),
@@ -59,4 +63,52 @@ def test_request_header_validation():
     assert_error_message_equal(
         err.value.messages[0]['request'][0][0]['parameters'][0]['headers'][0]['Authorization'][0]['type'][0],
         MESSAGES['type']['invalid'],
+    )
+
+
+@pytest.mark.parametrize(
+    'format_,value',
+    (
+        (CSV, '1,2,3'),
+        (SSV, '1 2 3'),
+        (TSV, '1\t2\t3'),
+        (PIPES, '1|2|3'),
+    ),
+)
+def test_request_header_array_extraction(format_, value):
+    schema = SchemaFactory(
+        paths={
+            '/get/': {
+                'get': {
+                    'responses': {200: {'description': "Success"}},
+                    'parameters': [
+                        {
+                            'name': 'Authorization',
+                            'in': HEADER,
+                            'type': ARRAY,
+                            'collectionFormat': format_,
+                            'minItems': 3,
+                            'maxItems': 3,
+                            'items': {
+                                'type': INTEGER,
+                                'minimum': 1,
+                                'maximum': 3,
+                            },
+                        },
+                    ],
+                },
+            },
+        },
+    )
+
+    response = ResponseFactory(
+        url='http://www.example.com/get/',
+        request__headers={'Authorization': value},
+    )
+
+    validate_api_call(
+        response,
+        paths=schema['paths'],
+        base_path=schema.get('base_path', ''),
+        context=schema,
     )

--- a/tests/validation/response/test_request_method_validation.py
+++ b/tests/validation/response/test_request_method_validation.py
@@ -1,7 +1,7 @@
 import pytest
 
 from flex.validation.response import (
-    validate_response,
+    validate_api_call,
 )
 from flex.error_messages import MESSAGES
 
@@ -30,7 +30,7 @@ def test_response_validation_with_invalid_operation_on_path():
     response = ResponseFactory(url='http://www.example.com/post')
 
     with pytest.raises(ValidationError) as err:
-        validate_response(
+        validate_api_call(
             response,
             paths=schema['paths'],
             base_path=schema.get('base_path', ''),

--- a/tests/validation/response/test_request_parameter_validation.py
+++ b/tests/validation/response/test_request_parameter_validation.py
@@ -1,7 +1,7 @@
 import pytest
 
 from flex.validation.response import (
-    validate_response,
+    validate_api_call,
 )
 from flex.error_messages import MESSAGES
 from flex.constants import (
@@ -54,7 +54,7 @@ def test_response_parameter_validation():
     response = ResponseFactory(url='http://www.example.com/get/32/?page=abcd')
 
     with pytest.raises(ValidationError) as err:
-        validate_response(
+        validate_api_call(
             response,
             paths=schema['paths'],
             base_path=schema.get('base_path', ''),

--- a/tests/validation/response/test_request_path_validation.py
+++ b/tests/validation/response/test_request_path_validation.py
@@ -2,7 +2,7 @@ import pytest
 
 from flex.serializers.core import PathsSerializer
 from flex.validation.response import (
-    validate_response,
+    validate_api_call,
     validate_request_to_path,
 )
 from flex.error_messages import MESSAGES
@@ -32,7 +32,7 @@ def test_response_validation_with_invalid_request_path():
     response = ResponseFactory(url='http://www.example.com/not-an-api-path')
 
     with pytest.raises(ValidationError) as err:
-        validate_response(
+        validate_api_call(
             response,
             paths=schema['paths'],
             base_path=schema.get('base_path', ''),

--- a/tests/validation/response/test_response_header_validation.py
+++ b/tests/validation/response/test_response_header_validation.py
@@ -1,0 +1,57 @@
+import pytest
+
+from flex.validation.response import (
+    validate_api_call,
+)
+from flex.error_messages import MESSAGES
+from flex.constants import (
+    INTEGER,
+)
+
+from tests.factories import (
+    SchemaFactory,
+    ResponseFactory,
+)
+from tests.utils import assert_error_message_equal
+
+
+def test_response_header_validation():
+    from django.core.exceptions import ValidationError
+
+    schema = SchemaFactory(
+        paths={
+            '/get/': {
+                'get': {
+                    'responses': {200: {
+                        'description': "Success",
+                        'headers': {
+                            'Foo': {'type': INTEGER},
+                        }
+                    }},
+                },
+            },
+        },
+    )
+
+    response = ResponseFactory(
+        url='http://www.example.com/get/',
+        headers={'Foo': 'abc'},
+    )
+
+    with pytest.raises(ValidationError) as err:
+        validate_api_call(
+            response,
+            paths=schema['paths'],
+            base_path=schema.get('base_path', ''),
+            context=schema,
+            inner=True,
+        )
+
+    assert 'response' in err.value.messages[0]
+    assert 'headers' in err.value.messages[0]['response'][0]
+    assert 'Foo' in err.value.messages[0]['response'][0]['headers'][0]
+    assert 'type' in err.value.messages[0]['response'][0]['headers'][0]['Foo'][0]
+    assert_error_message_equal(
+        err.value.messages[0]['response'][0]['headers'][0]['Foo'][0]['type'][0],
+        MESSAGES['type']['invalid'],
+    )

--- a/tests/validation/response/test_response_status_code_validation.py
+++ b/tests/validation/response/test_response_status_code_validation.py
@@ -1,7 +1,7 @@
 import pytest
 
 from flex.validation.response import (
-    validate_response,
+    validate_api_call,
 )
 from flex.error_messages import MESSAGES
 
@@ -33,7 +33,7 @@ def test_response_parameter_validation():
     response = ResponseFactory(url='http://www.example.com/get', status_code=301)
 
     with pytest.raises(ValidationError) as err:
-        validate_response(
+        validate_api_call(
             response,
             paths=schema['paths'],
             base_path=schema.get('base_path', ''),

--- a/tests/validation/response/test_schema_validation.py
+++ b/tests/validation/response/test_schema_validation.py
@@ -5,7 +5,7 @@ from flex.constants import (
     INTEGER,
 )
 from flex.validation.response import (
-    generate_response_validator,
+    generate_api_call_validator,
 )
 from flex.error_messages import MESSAGES
 
@@ -32,7 +32,7 @@ def test_basic_response_body_schema_validation_with_invalid_value():
             },
         },
     )
-    response_validator = generate_response_validator(schema, inner=True)
+    response_validator = generate_api_call_validator(schema, inner=True)
 
     response = ResponseFactory(
         url='http://www.example.com/get',
@@ -44,9 +44,10 @@ def test_basic_response_body_schema_validation_with_invalid_value():
     with pytest.raises(ValidationError) as err:
         response_validator(response)
 
-    assert 'response_body' in err.value.messages[0]
-    assert 'type' in err.value.messages[0]['response_body'][0]
+    assert 'response' in err.value.messages[0]
+    assert 'schema' in err.value.messages[0]['response'][0]
+    assert 'type' in err.value.messages[0]['response'][0]['schema'][0]
     assert_error_message_equal(
-        err.value.messages[0]['response_body'][0]['type'][0],
+        err.value.messages[0]['response'][0]['schema'][0]['type'][0],
         MESSAGES['type']['invalid'],
     )


### PR DESCRIPTION
### What is the problem / feature ?

Response headers were not being validated
### How did it get fixed / implemented ?

Added validation to the response headers.
### How can someone test / see it ?

See that response headers of non-string-types are validated correctly.

_Here is a cute animal picture for your troubles..._

![tongue-polar-bear](https://cloud.githubusercontent.com/assets/824194/5002843/b0e35950-69c2-11e4-8243-665010d1b32b.jpg)
