### PR TITLE
Fix request path validation

### DIFF
--- a/flex/validation/operation.py
+++ b/flex/validation/operation.py
@@ -16,6 +16,7 @@ from flex.constants import (
 from flex.parameters import (
     filter_parameters,
     merge_parameter_lists,
+    dereference_parameter_list,
 )
 from flex.validation.parameter import (
     validate_query_parameters,
@@ -107,8 +108,15 @@ def generate_parameters_validator(api_path, path_definition, parameters,
     # TODO: figure out how to merge this with the same code in response
     # validation.
     validators = {}
-    path_level_parameters = path_definition.get('parameters', [])
-    operation_level_parameters = parameters
+    parameter_definitions = context.get('parameters', {})
+    path_level_parameters = dereference_parameter_list(
+        path_definition.get('parameters', []),
+        parameter_definitions,
+    )
+    operation_level_parameters = dereference_parameter_list(
+        parameters,
+        parameter_definitions,
+    )
 
     all_parameters = merge_parameter_lists(
         path_level_parameters,

--- a/tests/validation/response/test_response_path_validation.py
+++ b/tests/validation/response/test_response_path_validation.py
@@ -95,9 +95,10 @@ def test_response_validation_with_parametrized_path():
     )
 
 
-def test_response_validation_with_parametrized_path():
+def test_response_validation_with_parametrized_path_and_invalid_value():
     """
-    Test that request validation does type checking on path parameters.
+    Test that request validation does type checking on path parameters.  Ensure
+    that the value in the path is validated.
     """
     schema = SchemaFactory(
         paths={


### PR DESCRIPTION
### What is the problem / feature ?

Request path validation was broken in the recent 2.5.0 release.
### How did it get fixed / implemented ?

Needed to de-reference the parameters being passed into the path validation.
### How can someone test / see it ?

Try to validate a parametrized path.

_Here is a cute animal picture for your troubles..._

![54489-christmas-animals](https://cloud.githubusercontent.com/assets/824194/5463515/f471f65c-853a-11e4-8662-d0d373aea7a4.jpg)
