### PR TITLE
Fix path parameter validation when basePath is present

### DIFF
--- a/flex/validation/parameter.py
+++ b/flex/validation/parameter.py
@@ -42,20 +42,23 @@ def type_cast_parameters(parameter_values, parameter_definitions, context):
     return typed_parameters
 
 
-def get_path_parameter_values(request_path, api_path, path_parameters, context):
+def get_path_parameter_values(target_path, api_path, path_parameters, context):
     raw_values = path_to_regex(
         api_path,
         path_parameters,
-    ).match(request_path).groupdict()
+    ).match(target_path).groupdict()
     return type_cast_parameters(raw_values, path_parameters, context=context)
 
 
-def validate_path_parameters(request_path, api_path, path_parameters, context):
+def validate_path_parameters(target_path, api_path, path_parameters, context):
     """
     Helper function for validating a request path
     """
+    base_path = context.get('basePath', '')
+    if target_path.startswith(base_path):
+        target_path = target_path[len(base_path):]
     parameter_values = get_path_parameter_values(
-        request_path, api_path, path_parameters, context,
+        target_path, api_path, path_parameters, context,
     )
     validate_parameters(parameter_values, path_parameters, context=context)
 

--- a/tests/core/test_match_request_path_to_api_path.py
+++ b/tests/core/test_match_request_path_to_api_path.py
@@ -119,7 +119,7 @@ def test_path_to_regex_does_not_overmatch(path, bad_path):
         ('/api/get/1', '/get/{id}'),
     ),
 )
-def test_match_request_path_to_api_path(path, schema_path):
+def test_match_target_path_to_api_path(path, schema_path):
     schema = load('tests/core/path_test_schema.yaml')
     paths = schema['paths']
     base_path = schema['basePath']

--- a/tests/validation/parameter/test_path_parameter_extraction.py
+++ b/tests/validation/parameter/test_path_parameter_extraction.py
@@ -31,7 +31,7 @@ def test_getting_parameter_values_from_path():
     parameters = serializer.save()
 
     values = get_path_parameter_values(
-        request_path='/get/fernando/posts/1234/',
+        target_path='/get/fernando/posts/1234/',
         api_path='/get/{username}/posts/{id}/',
         path_parameters=parameters,
         context={},

--- a/tests/validation/request/test_request_parameter_validation.py
+++ b/tests/validation/request/test_request_parameter_validation.py
@@ -69,3 +69,36 @@ def test_request_parameter_validation():
         err.value.detail,
         'query.page.type',
     )
+
+
+def test_request_parameter_validation_with_base_path():
+    """
+    Test that path parameter validation works even when there is a base path in
+    the api.
+    """
+    schema = SchemaFactory(
+        basePath='/api/v1',
+        paths={
+            '/get/{id}/': {
+                'parameters': [
+                    {
+                        'name': 'id',
+                        'in': PATH,
+                        'description': 'id',
+                        'required': True,
+                        'type': STRING,
+                    },
+                ],
+                'get': {
+                    'responses': {200: {'description': "Success"}},
+                },
+            },
+        },
+    )
+
+    request = RequestFactory(url='http://www.example.com/api/v1/get/32/')
+
+    validate_request(
+        request=request,
+        schema=schema,
+    )

--- a/tests/validation/request/test_request_path_validation.py
+++ b/tests/validation/request/test_request_path_validation.py
@@ -40,17 +40,16 @@ def test_request_validation_with_invalid_request_path():
     )
 
 
-def test_request_validation_with_valid_request_path():
+def test_request_validation_with_valid_path():
     """
-    Test that request validation detects request paths that are not declared
-    in the schema.
+    Test that request validation is able to match api paths.
     """
     schema = SchemaFactory(
         paths={
             '/get': {
                 'get': {'responses': {200: {'description': 'Success'}}},
             },
-        }
+        },
     )
 
     request = RequestFactory(url='http://www.example.com/get')
@@ -153,6 +152,30 @@ def test_request_validation_with_parameter_as_reference():
     )
 
     request = RequestFactory(url='http://www.example.com/get/1234')
+
+    validate_request(
+        request=request,
+        schema=schema,
+    )
+
+
+def test_request_validation_with_valid_path_and_base_path():
+    """
+    Test that request validation is able to match api paths that also have a
+    base api path.
+    """
+    schema = SchemaFactory(
+        basePath='/api/v1',
+        paths={
+            '/get': {
+                'get': {
+                    'responses': {200: {'description': "Success"}},
+                },
+            },
+        },
+    )
+
+    request = RequestFactory(url='http://www.example.com/api/v1/get')
 
     validate_request(
         request=request,

--- a/tests/validation/response/test_response_path_validation.py
+++ b/tests/validation/response/test_response_path_validation.py
@@ -45,8 +45,7 @@ def test_response_validation_with_invalid_path():
 
 def test_response_validation_with_valid_path():
     """
-    Test that request validation detects request paths that are not declared
-    in the schema.
+    Test that response validation is able to match api paths.
     """
     schema = SchemaFactory(
         paths={
@@ -57,6 +56,29 @@ def test_response_validation_with_valid_path():
     )
 
     response = ResponseFactory(url='http://www.example.com/get')
+
+    validate_response(
+        response=response,
+        request_method='get',
+        schema=schema,
+    )
+
+
+def test_response_validation_with_valid_path_and_base_path():
+    """
+    Test that response validation is able to match api paths even when there is
+    a base path.
+    """
+    schema = SchemaFactory(
+        basePath='/api/v1',
+        paths={
+            '/get': {
+                'get': {'responses': {200: {'description': 'Success'}}},
+            },
+        }
+    )
+
+    response = ResponseFactory(url='http://www.example.com/api/v1/get')
 
     validate_response(
         response=response,
@@ -87,6 +109,38 @@ def test_response_validation_with_parametrized_path():
     )
 
     response = ResponseFactory(url='http://www.example.com/get/1234')
+
+    validate_response(
+        response=response,
+        request_method='get',
+        schema=schema,
+    )
+
+
+def test_response_validation_with_parametrized_path_and_api_base_path():
+    """
+    Test that request validation finds and validates parametrized paths even
+    when the api has a base path.
+    """
+    schema = SchemaFactory(
+        basePath='/api/v1',
+        paths={
+            '/get/{id}': {
+                'get': {'responses': {200: {'description': 'Success'}}},
+                'parameters': [
+                    {
+                        'name': 'id',
+                        'in': PATH,
+                        'description': 'The Primary Key',
+                        'type': INTEGER,
+                        'required': True,
+                    }
+                ]
+            },
+        }
+    )
+
+    response = ResponseFactory(url='http://www.example.com/api/v1/get/1234')
 
     validate_response(
         response=response,


### PR DESCRIPTION
### What is the problem / feature ?

Request and Response path parameter validation is broken when working with an API with a base path.
### How did it get fixed / implemented ?

Stripped the base path off of the request/response path
### How can someone test / see it ?

Try validating a response/request for an api with a base path

_Here is a cute animal picture for your troubles..._

![pets-christmas-for-the-animal-197112](https://cloud.githubusercontent.com/assets/824194/5466810/90dc65c4-8570-11e4-9073-429cabd84c71.jpg)
