### PR TITLE
fix validation for consumes/produces with null content-types

### DIFF
--- a/flex/validation/operation.py
+++ b/flex/validation/operation.py
@@ -44,7 +44,8 @@ def validate_operation(request, validators):
 
 def validate_request_content_type(request, content_types):
     assert isinstance(request, Request)
-    if request.content_type not in content_types:
+    # TODO: is it correct to skip validation for a null content_type?
+    if request.content_type and request.content_type not in content_types:
         raise ValidationError(
             'Invalid content type `{0}`.  Must be one of `{1}`.'.format(
                 request.content_type, content_types,

--- a/flex/validation/response.py
+++ b/flex/validation/response.py
@@ -94,7 +94,7 @@ def generate_response_header_validator(headers, context, **kwargs):
 
 def validate_response_content_type(response, content_types):
     assert isinstance(response, Response)  # TODO: remove this sanity check
-    if response.content_type not in content_types:
+    if response.content_type and response.content_type not in content_types:
         raise ValidationError(
             MESSAGES['content_type']['invalid'].format(
                 response.content_type, content_types,

--- a/tests/validation/request/test_request_content_type_validation.py
+++ b/tests/validation/request/test_request_content_type_validation.py
@@ -1,0 +1,31 @@
+from flex.validation.request import (
+    validate_request,
+)
+
+from tests.factories import (
+    SchemaFactory,
+    RequestFactory,
+)
+
+
+def test_request_validation_with_invalid_operation_on_path():
+    schema = SchemaFactory(
+        consumes=['application/json'],
+        paths={
+            '/get': {
+                'get': {
+                    'responses': {200: {'description': 'Success'}},
+                }
+            },
+        },
+    )
+
+    request = RequestFactory(
+        url='http://www.example.com/get',
+        content_type=None,
+    )
+
+    validate_request(
+        request=request,
+        schema=schema,
+    )

--- a/tests/validation/response/test_response_content_type_validation.py
+++ b/tests/validation/response/test_response_content_type_validation.py
@@ -1,0 +1,33 @@
+from flex.validation.response import (
+    validate_response,
+)
+
+from tests.factories import (
+    SchemaFactory,
+    ResponseFactory,
+)
+
+
+def test_response_validation_with_invalid_operation_on_path():
+    schema = SchemaFactory(
+        produces=['application/json'],
+        paths={
+            '/get': {
+                'get': {
+                    'responses': {200: {'description': 'Success'}},
+                }
+            },
+        },
+    )
+
+    response = ResponseFactory(
+        url='http://www.example.com/get',
+        content_type=None,
+    )
+
+    validate_response(
+        response=response,
+        request_method='get',
+        schema=schema,
+    )
+


### PR DESCRIPTION
### What is the problem / feature ?

Validation of produces/consumes would fail on null content types.
### How did it get fixed / implemented ?

Skip validation if the content-type is null.
### How can someone test / see it ?

Validate a request/response with a null content-type

_Here is a cute animal picture for your troubles..._

![1248874-bigthumbnail](https://cloud.githubusercontent.com/assets/824194/5467050/8dafc1de-8575-11e4-947b-c318c87daf59.jpg)
