### PR TITLE
Fix issues with enum and binary/unicode test types

### DIFF
--- a/flex/utils.py
+++ b/flex/utils.py
@@ -19,12 +19,16 @@ from flex.constants import (
 )
 
 
-def is_non_string_iterable(value):
+def is_any_string_type(value):
     if six.PY2:
         string_types = six.string_types
     else:
         string_types = (six.binary_type, six.text_type)
-    return not isinstance(value, string_types) and hasattr(value, '__iter__')
+    return isinstance(value, string_types)
+
+
+def is_non_string_iterable(value):
+    return not is_any_string_type(value) and hasattr(value, '__iter__')
 
 
 def is_value_of_type(value, type_):
@@ -42,6 +46,25 @@ def is_value_of_type(value, type_):
 
 def is_value_of_any_type(value, types):
     return any(is_value_of_type(value, type_) for type_ in types)
+
+
+def deep_equal(a, b):
+    """
+    Because of things in python like:
+        >>> 1 == 1.0
+        True
+        >>> 1 == True
+        True
+        >>> b'test' == 'test'  # python3
+        False
+    """
+    if is_any_string_type(a) and is_any_string_type(b):
+        if isinstance(a, six.binary_type):
+            a = six.text_type(a, encoding='utf-8')
+        if isinstance(b, six.binary_type):
+            b = six.text_type(b, encoding='utf-8')
+        return a == b
+    return a == b and isinstance(a, type(b)) and isinstance(b, type(a))
 
 
 def cast_value_to_type(value, type_):

--- a/flex/validation/common.py
+++ b/flex/validation/common.py
@@ -22,6 +22,7 @@ from flex.utils import (
     get_type_for_value,
     chain_reduce_partial,
     cast_value_to_type,
+    deep_equal,
 )
 from flex.paths import (
     match_path_to_api_path,
@@ -274,19 +275,6 @@ def validate_pattern(value, regex):
 
 def generate_pattern_validator(pattern, **kwargs):
     return functools.partial(validate_pattern, regex=re.compile(pattern))
-
-
-def deep_equal(a, b):
-    """
-    Because of things in python like:
-        >>> 1 == 1.0
-        True
-        >>> 1 == True
-        True
-    """
-    if isinstance(a, six.string_types) and isinstance(b, six.string_types):
-        return a == b
-    return a == b and isinstance(a, type(b)) and isinstance(b, type(a))
 
 
 @skip_if_empty

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -13,6 +13,8 @@ from flex.utils import (
     get_type_for_value,
     cast_value_to_type,
     chain_reduce_partial,
+    is_any_string_type,
+    deep_equal,
 )
 from flex.constants import (
     NULL,
@@ -376,3 +378,44 @@ def test_chain_reduce_partial():
     for _ in range(100):
         v = random.randint(-1000000, 1000000)
         assert fn_c(v) == fn_b(fn_a(v))
+
+
+#
+# is_any_string_type tests
+#
+def test_binary_type():
+    assert is_any_string_type(six.binary_type(b'test'))
+
+
+def test_text_type():
+    assert is_any_string_type(six.text_type('test'))
+
+
+def test_not_a_string_at_all():
+    assert not is_any_string_type(1)
+
+
+#
+# deep_equal tests
+#
+@pytest.mark.parametrize(
+    'left,right',
+    (
+        (1, True),
+        (1.0, True),
+        (1, 1.0),
+        (0, False),
+    )
+)
+def test_deep_equal_for_things_that_should_not_be_equal(left, right):
+    assert not deep_equal(left, right)
+
+
+@pytest.mark.parametrize(
+    'left,right',
+    (
+        (six.binary_type(b'test'), six.text_type('test')),
+    )
+)
+def test_deep_equal_for_things_that_should_be_equal(left, right):
+    assert deep_equal(left, right)

--- a/tests/validation/schema/test_enum_validation.py
+++ b/tests/validation/schema/test_enum_validation.py
@@ -60,9 +60,9 @@ def test_enum_noop_when_not_required_and_field_not_present():
     'enum_value,value',
     (
         (six.text_type('test'), six.text_type('test')),
-        (six.text_type('test'), six.binary_type('test')),
-        (six.binary_type('test'), six.text_type('test')),
-        (six.binary_type('test'), six.binary_type('test')),
+        (six.text_type('test'), b'test'),
+        (b'test', six.text_type('test')),
+        (b'test', b'test'),
     )
 )
 def test_enum_disperate_text_types(enum_value, value):
@@ -71,4 +71,4 @@ def test_enum_disperate_text_types(enum_value, value):
     }
     validator = generate_validator_from_schema(schema)
 
-    validator(six.text_type(value))
+    validator(value)


### PR DESCRIPTION
### What is the problem / feature ?

The way that `enum` validation worked did not thing that unicode and binary strings were the same.
### How did it get fixed / implemented ?

Changed how the `deep_equal` function worked such that it special cases the equality when both values are of a string type.
### How can someone test / see it ?

Do enum validation on strings.

_Here is a cute animal picture for your troubles..._

![labrador-puppy-with-xmas-present](https://cloud.githubusercontent.com/assets/824194/5477501/280b7476-85e9-11e4-9089-fb4fdb9021ba.jpg)
