### PR TITLE
Fix bug in query parameter validation

### DIFF
--- a/flex/validation/operation.py
+++ b/flex/validation/operation.py
@@ -61,18 +61,6 @@ def generate_request_content_type_validator(consumes, **kwargs):
     return validator
 
 
-def generate_query_parameters_validator(query_parameters, context):
-    query_parameter_validator = functools.partial(
-        validate_query_parameters,
-        query_parameters=query_parameters,
-        context=context,
-    )
-    return chain_reduce_partial(
-        operator.attrgetter('query_data'),
-        query_parameter_validator,
-    )
-
-
 def generate_header_validator(headers, context, **kwargs):
     """
     Generates a validation function that will validate a dictionary of headers.
@@ -133,7 +121,14 @@ def generate_parameters_validator(api_path, path_definition, parameters,
 
     # QUERY
     in_query_parameters = filter_parameters(all_parameters, in_=QUERY)
-    validators['query'] = generate_query_parameters_validator(in_query_parameters, context)
+    validators['query'] = chain_reduce_partial(
+        operator.attrgetter('query_data'),
+        functools.partial(
+            validate_query_parameters,
+            query_parameters=in_query_parameters,
+            context=context,
+        ),
+    )
 
     # HEADERS
     in_header_parameters = filter_parameters(all_parameters, in_=HEADER)

--- a/flex/validation/parameter.py
+++ b/flex/validation/parameter.py
@@ -77,9 +77,6 @@ def validate_parameters(parameter_values, parameters, context):
     validators = construct_multi_parameter_validators(parameters, context=context)
 
     with ErrorCollection() as errors:
-        # we should have a validator for every parameter value
-        assert not set(parameter_values.keys()).difference(validators.keys())
-
         for key, validator in validators.items():
             try:
                 validator(parameter_values.get(key, EMPTY))

--- a/tests/validation/request/test_request_query_parameter_validation.py
+++ b/tests/validation/request/test_request_query_parameter_validation.py
@@ -1,0 +1,52 @@
+from flex.validation.request import (
+    validate_request,
+)
+from flex.error_messages import MESSAGES
+from flex.constants import (
+    PATH,
+    QUERY,
+    STRING,
+    INTEGER,
+)
+
+from tests.factories import (
+    SchemaFactory,
+    RequestFactory,
+)
+from tests.utils import assert_message_in_errors
+
+
+def test_request_query_parameter_validation_with_no_declared_parameters():
+    """
+    Ensure that when a query parameter is present with no definition within the
+    schema that it is ignored.  We need to have at least one parameter at play
+    to trigger parameter validation to happen for this endpoint.
+    """
+    schema = SchemaFactory(
+        parameters = {
+            'id': {
+                'name': 'id',
+                'in': PATH,
+                'description': 'id',
+                'required': True,
+                'type': INTEGER,
+            },
+        },
+        paths={
+            '/get/{id}/': {
+                'parameters': [
+                    'id',
+                ],
+                'get': {
+                    'responses': {200: {'description': "Success"}},
+                },
+            },
+        },
+    )
+
+    request = RequestFactory(url='http://www.example.com/get/3/?page=3')
+
+    validate_request(
+        request=request,
+        schema=schema,
+    )


### PR DESCRIPTION
### What is the problem / feature ?

Query parameter validation was failing on an edge case.
- query parameters present in the request and the operation definition which don't overlap.
### How did it get fixed / implemented ?

fixed the logic.
### How can someone test / see it ?

Validate a request with query parameters against an operation with other parameters.

_Here is a cute animal picture for your troubles..._

![christmas-animals-002](https://cloud.githubusercontent.com/assets/824194/5482223/47087988-861a-11e4-9adf-dda7eef69c94.jpg)
