### PR TITLE
Fix for pip>=6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from pip.req import parse_requirements
+from pip.download import PipSession
 import os
 
 DIR = os.path.dirname(os.path.abspath(__file__))
@@ -14,7 +15,9 @@ version = '2.8.0'
 
 readme = open(os.path.join(DIR, 'README.md')).read()
 
-requirements = [str(req.req) for req in parse_requirements('requirements.txt')]
+requirements = [
+    str(req.req) for req in parse_requirements('requirements.txt', session=PipSession())
+]
 
 
 setup(


### PR DESCRIPTION
### What is the problem / feature ?

`pip >= 6` introduced `session` as a required argument for `parse_requirements`

### How did it get fixed / implemented ?

Added a `session` to the call.

### How can someone test / see it ?

See the tests pass.

*Here is a cute animal picture for your troubles...*

![article-1362971-0d76ec92000005dc-260_634x694](https://cloud.githubusercontent.com/assets/824194/5821380/eba317fe-a088-11e4-9f7d-5f976056dade.jpg)
