### PR TITLE
#45 - Updating documentation for validate_api_call

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -120,7 +120,7 @@ swagger schema.
    >>> from flex.core import load, validate_api_call
    >>> schema = load("path/to/schema.yaml")
    >>> response = requests.get('http://www.example.com/api/')
-   >>> validate_api_call(schema, request=response.request, response=response)
+   >>> validate_api_call(schema, raw_request=response.request, raw_response=response)
    ValueError: Invalid
    'response':
        - 'Request status code was not found in the known response codes.  Got `301`: Expected one of: `[200]`'


### PR DESCRIPTION
I updated the documentation for the validate_api_call method. Basically I changed the name of the parameters.

In this [commit](https://github.com/pipermerriam/flex/commit/6dd40bf9ce451b2e48565432acb0a32e79c0afc0#diff-f3a867d094642f074d48613d6330c28f) the validate_api_call was changed:
```ssh
-def validate_api_call(schema, request, response):
+def validate_api_call(schema, raw_request, raw_response):
```
So I updated the documentation.