### PR TITLE
fixes #45 - Fix docs for validate_api_call

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -120,7 +120,7 @@ swagger schema.
    >>> from flex.core import load, validate_api_call
    >>> schema = load("path/to/schema.yaml")
    >>> response = requests.get('http://www.example.com/api/')
-   >>> validate_api_call(schema, request=response.request, response=response)
+   >>> validate_api_call(schema, raw_request.request, raw_response=response)
    ValueError: Invalid
    'response':
        - 'Request status code was not found in the known response codes.  Got `301`: Expected one of: `[200]`'


### PR DESCRIPTION
### What is the problem / feature ?

The documentation for `validate_api_call` was incorrect.

### How did it get fixed / implemented ?

Updated it to use the correct keyword arguments `raw_request/raw_response`.

### How can someone test / see it ?

Pass a request/response onto the function as a keyword argument.

*Here is a cute animal picture for your troubles...*

![jack-russel-freddie-with-percy](https://cloud.githubusercontent.com/assets/824194/5990042/8e071a96-a95c-11e4-9532-dd3e6a525b1c.jpg)
