### PR TITLE
Fixing typo in paths.py

### DIFF
--- a/flex/paths.py
+++ b/flex/paths.py
@@ -127,7 +127,7 @@ def match_path_to_api_path(path_definitions, target_path, base_path='', global_p
     if not matches:
         raise LookupError('No paths found for {0}'.format(target_path))
     elif len(matches) > 1:
-        raise LookupError('Multipue paths found for {0}.  Found `{1}`'.format(
+        raise LookupError('Multiple paths found for {0}.  Found `{1}`'.format(
             target_path, matches,
         ))
     else:


### PR DESCRIPTION
Fixed little typo in the file paths.py:

```ssh
-        raise LookupError('Multipue paths found for {0}.  Found `{1}`'.format(
+        raise LookupError('Multiple paths found for {0}.  Found `{1}`'.format(
```

Sorry, I forgot the **cute animal**: 
![745748-16655f34-81bb-11e4-b7a3-5366c32c384a](https://cloud.githubusercontent.com/assets/6579348/6152347/2dded184-b1fb-11e4-9da6-3b6d6b3c9f6c.jpg)
