### PR TITLE
Fixes #56 - handle multiple paths found a bit smarter

### DIFF
--- a/flex/error_messages.py
+++ b/flex/error_messages.py
@@ -145,6 +145,10 @@ RESPONSE_MESSAGES = {
 
 
 PATH_MESSAGES = {
+    'no_matching_paths_found': 'No paths found for {0}',
+    'multiple_paths_found': (
+        'Unable to determine path for {0}.  Found multiple matches: `{1}`'
+    ),
     'unknown_path': 'Request path did not match any of the known api paths.',
     'missing_parameter': (
         "The parameter named `{0}` is declared to be a PATH parameter but does "

--- a/flex/exceptions.py
+++ b/flex/exceptions.py
@@ -88,3 +88,7 @@ class ValidationError(ValueError):
         elif isinstance(self._error, collections.Mapping):
             return [self._error]
         return self._error
+
+
+class MultiplePathsFound(ValueError):
+    pass

--- a/flex/validation/common.py
+++ b/flex/validation/common.py
@@ -12,6 +12,7 @@ from flex.exceptions import (
     ValidationError,
     ErrorDict,
     ErrorList,
+    MultiplePathsFound,
 )
 from flex.datastructures import (
     ValidationDict,
@@ -455,7 +456,9 @@ def validate_path_to_api_path(path, paths, basePath='', parameters=None, **kwarg
             base_path=basePath,
             global_parameters=parameters,
         )
-    except LookupError:
-        raise ValidationError(MESSAGES['path']['unknown_path'])
+    except LookupError as err:
+        raise ValidationError(str(err))
+    except MultiplePathsFound as err:
+        raise ValidationError(str(err))
 
     return api_path

--- a/tests/core/test_match_request_path_to_api_path.py
+++ b/tests/core/test_match_request_path_to_api_path.py
@@ -165,3 +165,45 @@ def test_match_path_with_parameter_defined_in_operation():
         target_path='/get/1234',
     )
     assert path == '/get/{id}'
+
+
+def test_matching_with_nested_path():
+    schema = SchemaFactory(
+        paths={
+            '/get/{id}': {
+                'get': {
+                    'parameters': [{
+                        'name': 'id',
+                        'in': PATH,
+                        'type': STRING,
+                        'required': True,
+                    }],
+                },
+            },
+            '/get/{id}/nested/{other_id}': {
+                'get': {
+                    'parameters': [
+                        {
+                            'name': 'id',
+                            'in': PATH,
+                            'type': STRING,
+                            'required': True,
+                        },
+                        {
+                            'name': 'other_id',
+                            'in': PATH,
+                            'type': STRING,
+                            'required': True,
+                        },
+                    ],
+                },
+            },
+        },
+    )
+    paths = schema['paths']
+
+    path = match_path_to_api_path(
+        path_definitions=paths,
+        target_path='/get/1234/nested/5678',
+    )
+    assert path == '/get/{id}/nested/{other_id}'

--- a/tests/validation/path/test_validate_path_to_api_path.py
+++ b/tests/validation/path/test_validate_path_to_api_path.py
@@ -54,7 +54,7 @@ def test_basic_request_path_validation_with_unspecified_paths(request_path):
         )
 
     assert_message_in_errors(
-        MESSAGES['path']['unknown_path'],
+        MESSAGES['path']['no_matching_paths_found'],
         err.value.detail,
     )
 

--- a/tests/validation/request/test_request_path_validation.py
+++ b/tests/validation/request/test_request_path_validation.py
@@ -34,7 +34,7 @@ def test_request_validation_with_invalid_request_path():
         )
 
     assert_message_in_errors(
-        MESSAGES['path']['unknown_path'],
+        MESSAGES['path']['no_matching_paths_found'],
         err.value.detail,
         'path',
     )

--- a/tests/validation/response/test_response_path_validation.py
+++ b/tests/validation/response/test_response_path_validation.py
@@ -37,7 +37,7 @@ def test_response_validation_with_invalid_path():
         )
 
     assert_message_in_errors(
-        MESSAGES['path']['unknown_path'],
+        MESSAGES['path']['no_matching_paths_found'],
         err.value.detail,
         'path',
     )


### PR DESCRIPTION
### What is the problem / feature ?

- The function `flex.paths.match_path_to_api_path` considered multiple matches to be an error state.
- The error of no matches and multiple matches were not kept distinct so the error message was not helpful when multiple matches were found.

### How did it get fixed / implemented ?

- Added logic for when multiple matches are found to try and pick the match with the highest number of matching groups.  This fixes what is probably the most common case for this code failing which is having a nested resource (very common).
- Added distinct error reporting for the two error cases.

### How can someone test / see it ?

Try to validate a request/schema combination like the one found in #56 


*Here is a cute animal picture for your troubles...*

![unusual-animal-friendship-3-2](https://cloud.githubusercontent.com/assets/824194/6200935/ae0a93b8-b44c-11e4-95cb-f6193b33fbcf.jpg)
