### PR TITLE
Adding validation to see if the match is not None

### DIFF
--- a/flex/paths.py
+++ b/flex/paths.py
@@ -144,7 +144,8 @@ def match_path_to_api_path(path_definitions, target_path, base_path='', global_p
         for p, v in path_definitions.items()
     }
 
-    matching_api_paths = [p for p, r in paths.items() if r.match(target_path)]
+    matching_api_paths = [(p, r.match(target_path))
+                          for p, r in paths.items() if r.match(target_path)]
 
     if not matching_api_paths:
         raise LookupError(MESSAGES['path']['no_matching_paths_found'].format(target_path))
@@ -153,18 +154,16 @@ def match_path_to_api_path(path_definitions, target_path, base_path='', global_p
         # We check to see if any of the matches has more matched groups than
         # the others.  If so, we *assume* it is the correct match.  This is
         # going to be prone to false positives. in certain cases.
-        matches = [(p, r.match(target_path)) for p, r in paths.items()]
         matches_by_group_size = collections.defaultdict(list)
-        for path, match in matches:
-            if match:
-                matches_by_group_size[len(match.groups())].append(path)
+        for path, match in matching_api_paths:
+            matches_by_group_size[len(match.groups())].append(path)
         longest_match = max(matches_by_group_size.keys())
         if len(matches_by_group_size[longest_match]) == 1:
             return matches_by_group_size[longest_match][0]
         raise MultiplePathsFound(
             MESSAGES['path']['multiple_paths_found'].format(
-                target_path, matching_api_paths,
+                [v[0] for v in matching_api_paths]
             )
         )
     else:
-        return matching_api_paths[0]
+        return matching_api_paths[0][0]

--- a/flex/paths.py
+++ b/flex/paths.py
@@ -156,7 +156,8 @@ def match_path_to_api_path(path_definitions, target_path, base_path='', global_p
         matches = [(p, r.match(target_path)) for p, r in paths.items()]
         matches_by_group_size = collections.defaultdict(list)
         for path, match in matches:
-            matches_by_group_size[len(match.groups())].append(path)
+            if match:
+                matches_by_group_size[len(match.groups())].append(path)
         longest_match = max(matches_by_group_size.keys())
         if len(matches_by_group_size[longest_match]) == 1:
             return matches_by_group_size[longest_match][0]

--- a/tests/core/test_match_request_path_to_api_path.py
+++ b/tests/core/test_match_request_path_to_api_path.py
@@ -207,3 +207,47 @@ def test_matching_with_nested_path():
         target_path='/get/1234/nested/5678',
     )
     assert path == '/get/{id}/nested/{other_id}'
+
+def test_matching_with_full_nested_path():
+    schema = SchemaFactory(
+        paths={
+            '/get/main/':{
+                'get':{},
+            },
+            '/get/main/{id}': {
+                'get': {
+                    'parameters': [{
+                        'name': 'id',
+                        'in': PATH,
+                        'type': STRING,
+                        'required': True,
+                    }],
+                },
+            },
+            '/get/main/{id}/nested/{other_id}': {
+                'get': {
+                    'parameters': [
+                        {
+                            'name': 'id',
+                            'in': PATH,
+                            'type': STRING,
+                            'required': True,
+                        },
+                        {
+                            'name': 'other_id',
+                            'in': PATH,
+                            'type': STRING,
+                            'required': True,
+                        },
+                    ],
+                },
+            },
+        },
+    )
+    paths = schema['paths']
+
+    path = match_path_to_api_path(
+        path_definitions=paths,
+        target_path='/get/main/1234/nested/5678',
+    )
+    assert path == '/get/main/{id}/nested/{other_id}'


### PR DESCRIPTION
### What is the problem / feature ?

* The function match_path_to_api_path in paths.py was giving an error. Because the [matches](https://github.com/pipermerriam/flex/blob/master/flex/paths.py#L156) variable was something like this:
```ssh
[('/v1/pets/', None),
  ('/v1/pets/{petId}', <_sre.SRE_Match object; span=(0, 52), match='/v1/pets/1/name/lucky>), 
  ('/v1/pets/{petId}/name/{namePet}', <_sre.SRE_Match object; span=(0, 52), match='/v1/pets/1/name/lucky>)]
```
So in this [line](https://github.com/pipermerriam/flex/blob/master/flex/paths.py#L159) gives the error **"AttributeError: 'NoneType' object has no attribute 'groups'"**.

### How did it get fixed / implemented ?
Adding validation to see if the match is not None.

Here is a cute animal picture for your troubles...

![animalpull](https://cloud.githubusercontent.com/assets/6579348/6249270/dc899502-b764-11e4-933b-c0bd08174372.jpeg)


