### PR TITLE
Fixes #62 - Proper handling of required field on schema objects

### DIFF
--- a/flex/loading/common/schema/__init__.py
+++ b/flex/loading/common/schema/__init__.py
@@ -24,7 +24,7 @@ from .max_properties import (
     validate_max_properties_is_greater_than_or_equal_to_min_properties,
     validate_type_for_max_properties,
 )
-from flex.loading.common.required import (
+from .required import (
     required_validator,
 )
 from .type import (

--- a/flex/loading/common/schema/required.py
+++ b/flex/loading/common/schema/required.py
@@ -1,0 +1,24 @@
+from flex.constants import (
+    ARRAY,
+    STRING,
+)
+from flex.validation.common import (
+    generate_object_validator,
+)
+from flex.validation.schema import (
+    construct_schema_validators,
+)
+
+
+required_schema = {
+    'type': ARRAY,
+    'items': {
+        'type': STRING,
+    },
+    'uniqueItems': True,
+}
+required_validators = construct_schema_validators(required_schema, {})
+
+required_validator = generate_object_validator(
+    field_validators=required_validators,
+)

--- a/flex/loading/common/single_header/__init__.py
+++ b/flex/loading/common/single_header/__init__.py
@@ -44,6 +44,9 @@ from .collection_format import (
 
 single_header_schema = {
     'type': OBJECT,
+    'required': [
+        'type',
+    ]
 }
 
 single_header_field_validators = ValidationDict()

--- a/flex/loading/common/single_header/type.py
+++ b/flex/loading/common/single_header/type.py
@@ -22,7 +22,6 @@ ALLOWED_TYPES = [STRING, NUMBER, INTEGER, BOOLEAN, ARRAY]
 
 type_schema = {
     'type': [STRING, ARRAY],
-    'required': True,
     'items': {
         'type': STRING,
         'enum': ALLOWED_TYPES,

--- a/flex/loading/common/single_parameter/__init__.py
+++ b/flex/loading/common/single_parameter/__init__.py
@@ -45,6 +45,10 @@ from .items import (
 
 single_parameter_schema = {
     'type': OBJECT,
+    'required': [
+        'name',
+        'in',
+    ],
 }
 
 single_parameter_field_validators = ValidationDict()

--- a/flex/loading/common/single_parameter/in_.py
+++ b/flex/loading/common/single_parameter/in_.py
@@ -20,7 +20,6 @@ from flex.decorators import (
 in_schema = {
     'type': STRING,
     'enum': PARAMETER_IN_VALUES,
-    'required': True,
 }
 
 

--- a/flex/loading/common/single_parameter/name.py
+++ b/flex/loading/common/single_parameter/name.py
@@ -8,7 +8,6 @@ from flex.validation.common import (
 
 name_schema = {
     'type': STRING,
-    'required': True,
 }
 
 

--- a/flex/loading/definitions/responses/single/__init__.py
+++ b/flex/loading/definitions/responses/single/__init__.py
@@ -18,10 +18,12 @@ from .headers import (
 
 single_response_schema = {
     'type': OBJECT,
+    'required': [
+        'description',
+    ],
     'properties': {
         'description': {
             'type': STRING,
-            'required': True,
         },
     },
 }

--- a/flex/loading/schema/__init__.py
+++ b/flex/loading/schema/__init__.py
@@ -30,6 +30,11 @@ __ALL__ = [
 
 swagger_schema = {
     'type': OBJECT,
+    'required': [
+        'info',
+        'paths',
+        'swagger',
+    ],
 }
 
 non_field_validators = ValidationDict()

--- a/flex/loading/schema/info.py
+++ b/flex/loading/schema/info.py
@@ -7,10 +7,11 @@ from flex.validation.common import (
 
 
 info_schema = {
-    'required': True,
+    'required': [
+        'title',
+    ],
     'properties': {
         'title': {
-            'required': True,
             'type': STRING,
         },
         'description': {'type': STRING},

--- a/flex/loading/schema/paths/__init__.py
+++ b/flex/loading/schema/paths/__init__.py
@@ -37,7 +37,6 @@ def validate_path_items(paths, **kwargs):
 
 
 paths_schema = {
-    'required': True,
     'type': OBJECT,
 }
 non_field_validators = ValidationList()

--- a/flex/loading/schema/paths/path_item/__init__.py
+++ b/flex/loading/schema/paths/path_item/__init__.py
@@ -18,7 +18,6 @@ def parameters_validator(*args, **kwargs):
 
 path_item_schema = {
     'type': OBJECT,
-    'required': True,
 }
 
 non_field_validators = ValidationDict()

--- a/flex/loading/schema/paths/path_item/operation/responses/single/__init__.py
+++ b/flex/loading/schema/paths/path_item/operation/responses/single/__init__.py
@@ -18,10 +18,12 @@ from .schema import (
 
 single_response_schema = {
     'type': OBJECT,
+    'required': [
+        'description',
+    ],
     'properties': {
         'description': {
             'type': STRING,
-            'required': True,
         },
     },
 }

--- a/flex/loading/schema/swagger.py
+++ b/flex/loading/schema/swagger.py
@@ -8,7 +8,6 @@ from flex.validation.common import (
 
 swagger_version_schema = {
     'enum': ['2.0'],
-    'required': True,
     'type': STRING,
 }
 

--- a/flex/validation/common.py
+++ b/flex/validation/common.py
@@ -89,25 +89,6 @@ def noop(*args, **kwargs):
 
 
 @skip_if_empty
-@skip_if_not_of_type(OBJECT)
-def validate_required(value, required_fields, **kwargs):
-    with ErrorDict() as errors:
-        for key in required_fields:
-            if key not in value:
-                errors.add_error(key, MESSAGES['required']['required'])
-
-
-def generate_required_validator(required, **kwargs):
-    if required:
-        return functools.partial(
-            validate_required,
-            required_fields=required,
-        )
-    else:
-        return noop
-
-
-@skip_if_empty
 @skip_if_not_of_type(NUMBER)
 def validate_multiple_of(value, divisor, **kwargs):
     """

--- a/flex/validation/common.py
+++ b/flex/validation/common.py
@@ -31,7 +31,6 @@ from flex.paths import (
     match_path_to_api_path,
 )
 from flex.constants import (
-    EMPTY,
     NUMBER,
     STRING,
     ARRAY,
@@ -89,14 +88,21 @@ def noop(*args, **kwargs):
     pass
 
 
-def validate_required(value, **kwargs):
-    if value is EMPTY:
-        raise ValidationError(MESSAGES['required']['required'])
+@skip_if_empty
+@skip_if_not_of_type(OBJECT)
+def validate_required(value, required_fields, **kwargs):
+    with ErrorDict() as errors:
+        for key in required_fields:
+            if key not in value:
+                errors.add_error(key, MESSAGES['required']['required'])
 
 
 def generate_required_validator(required, **kwargs):
     if required:
-        return validate_required
+        return functools.partial(
+            validate_required,
+            required_fields=required,
+        )
     else:
         return noop
 

--- a/flex/validation/parameter.py
+++ b/flex/validation/parameter.py
@@ -1,11 +1,12 @@
 from flex.datastructures import ValidationDict
 from flex.utils import is_non_string_iterable
 from flex.exceptions import ValidationError
+from flex.error_messages import MESSAGES
 from flex.context_managers import ErrorCollection
 from flex.validation.common import (
+    noop,
     generate_type_validator,
     generate_format_validator,
-    generate_required_validator,
     generate_multiple_of_validator,
     generate_minimum_validator,
     generate_maximum_validator,
@@ -26,6 +27,18 @@ from flex.validation.schema import (
 from flex.parameters import find_parameter
 from flex.paths import path_to_regex
 from flex.constants import EMPTY
+
+
+def validate_required(value, **kwargs):
+    if value is EMPTY:
+        raise ValidationError(MESSAGES['required']['required'])
+
+
+def generate_required_validator(required, **kwargs):
+    if required:
+        return validate_required
+    else:
+        return noop
 
 
 def type_cast_parameters(parameter_values, parameter_definitions, context):

--- a/flex/validation/schema.py
+++ b/flex/validation/schema.py
@@ -7,6 +7,7 @@ import six
 from flex.exceptions import (
     ValidationError,
     ErrorList,
+    ErrorDict,
 )
 from flex.error_messages import MESSAGES
 from flex.constants import (
@@ -15,10 +16,10 @@ from flex.constants import (
 )
 from flex.decorators import skip_if_not_of_type
 from flex.validation.common import (
+    noop,
     skip_if_empty,
     generate_type_validator,
     generate_format_validator,
-    generate_required_validator,
     generate_multiple_of_validator,
     generate_minimum_validator,
     generate_maximum_validator,
@@ -35,6 +36,25 @@ from flex.validation.common import (
 from flex.datastructures import (
     ValidationDict,
 )
+
+
+@skip_if_empty
+@skip_if_not_of_type(OBJECT)
+def validate_required(value, required_fields, **kwargs):
+    with ErrorDict() as errors:
+        for key in required_fields:
+            if key not in value:
+                errors.add_error(key, MESSAGES['required']['required'])
+
+
+def generate_required_validator(required, **kwargs):
+    if required:
+        return functools.partial(
+            validate_required,
+            required_fields=required,
+        )
+    else:
+        return noop
 
 
 @skip_if_empty

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 python_paths= .
-addopts= --tb native
+addopts= --tb native -v

--- a/tests/loading/definition/responses/headers/single/test_type_validation.py
+++ b/tests/loading/definition/responses/headers/single/test_type_validation.py
@@ -22,7 +22,7 @@ def test_type_is_required(MESSAGES, msg_assertions):
     msg_assertions.assert_message_in_errors(
         MESSAGES['required']['required'],
         err.value.detail,
-        'type.required',
+        'required.type',
     )
 
 

--- a/tests/loading/definition/schema/test_required.py
+++ b/tests/loading/definition/schema/test_required.py
@@ -23,7 +23,7 @@ def test_required_is_not_required():
 
 @pytest.mark.parametrize(
     'value',
-    ([1, 2], None, {'a': 1}, 'abc', 1, 1.1),
+    (True, False, None, {'a': 1}, 'abc', 1, 1.1),
 )
 def test_required_with_invalid_types(value):
     with pytest.raises(ValidationError) as err:
@@ -36,9 +36,20 @@ def test_required_with_invalid_types(value):
     )
 
 
+def test_required_with_invalid_sub_types():
+    with pytest.raises(ValidationError) as err:
+        schema_validator({'required': ['field-A', True, 'Field-B']})
+
+    assert_message_in_errors(
+        MESSAGES['type']['invalid'],
+        err.value.detail,
+        'required.type',
+    )
+
+
 def test_required_for_valid_required():
     try:
-        schema_validator({'required': True})
+        schema_validator({'required': ['field-A', 'field-B']})
     except ValidationError as err:
         errors = err.detail
     else:

--- a/tests/loading/schema/test_info_validation.py
+++ b/tests/loading/schema/test_info_validation.py
@@ -34,7 +34,7 @@ def test_info_field_is_required():
     assert_message_in_errors(
         MESSAGES['required']['required'],
         err.value.detail,
-        'info.required',
+        'required.info',
     )
 
 
@@ -49,7 +49,7 @@ def test_title_is_required():
     assert_message_in_errors(
         MESSAGES['required']['required'],
         err.value.detail,
-        'title.required',
+        'required.title',
     )
 
 

--- a/tests/loading/schema/test_paths_validation.py
+++ b/tests/loading/schema/test_paths_validation.py
@@ -24,7 +24,7 @@ def test_paths_is_required():
     assert_message_in_errors(
         MESSAGES['required']['required'],
         err.value.detail,
-        'paths.required',
+        'required.paths',
     )
 
 

--- a/tests/loading/schema/test_swagger_validation.py
+++ b/tests/loading/schema/test_swagger_validation.py
@@ -34,7 +34,7 @@ def test_swagger_field_is_required():
     assert_message_in_errors(
         MESSAGES['required']['required'],
         err.value.detail,
-        'swagger.required',
+        'required.swagger',
     )
 
 
@@ -86,9 +86,9 @@ def test_swagger_field_with_invalid_version():
     (1, 1.1, True, ['a', 'b'], {'a': 'b'}, None),
 )
 def test_version_must_be_a_string(value):
-    data = {
-        'swagger': value,
-    }
+    data = RawSchemaFactory(
+        swagger=value,
+    )
     with pytest.raises(ValidationError) as err:
         swagger_schema_validator(data)
 

--- a/tests/validation/response/test_schema_validation.py
+++ b/tests/validation/response/test_schema_validation.py
@@ -72,9 +72,10 @@ def test_basic_response_body_schema_validation_with_type_mismatch():
                             'description': 'Success',
                             'schema': {
                                 'type': OBJECT,
+                                'required': ['id', 'name'],
                                 'properties': {
-                                    'id': {'type': INTEGER, 'required': True},
-                                    'name': {'type': STRING, 'required': True},
+                                    'id': {'type': INTEGER},
+                                    'name': {'type': STRING},
                                 },
                             },
                         }
@@ -114,26 +115,30 @@ def test_response_body_schema_validation_with_items_as_reference():
     schema = SchemaFactory(
         definitions={
             'User': {
+                'required': [
+                    'id',
+                    'name',
+                ],
                 'properties': {
                     'id': {
-                        'required': True,
                         'type': INTEGER,
                     },
                     'name': {
-                        'required': True,
                         'enum': ('bob', 'joe'),
                     },
                 },
             },
             'UserList': {
                 'type': OBJECT,
+                'required': [
+                    'results',
+                ],
                 'properties': {
                     'results': {
                         'type': ARRAY,
                         'items':{
                             '$ref': 'User',
                         },
-                        'required': True,
                     },
                 },
             },

--- a/tests/validation/schema/test_ref_validation.py
+++ b/tests/validation/schema/test_ref_validation.py
@@ -133,8 +133,9 @@ def test_reference_with_additional_validators_and_invalid_value(name):
 
 def test_reference_is_noop_when_not_required_and_not_provided():
     schema = {
-        '$ref': 'Name',
-        'required': False,
+        'properties': {
+            'name': {'$ref': 'Name'},
+        },
     }
     context = {
         'definitions': {
@@ -147,7 +148,7 @@ def test_reference_is_noop_when_not_required_and_not_provided():
     }
     validator = generate_validator_from_schema(schema, context=context)
 
-    validator(EMPTY)
+    validator({})
 
 
 def test_non_required_circular_reference():
@@ -189,8 +190,9 @@ def test_required_circular_reference():
     definitions = schema_definitions_validator(
         {
             'Node': {
+                'required': ['parent'],
                 'properties': {
-                    'parent': {'$ref': 'Node', 'required': True},
+                    'parent': {'$ref': 'Node'},
                 },
             },
         },
@@ -217,7 +219,7 @@ def test_required_circular_reference():
     assert_message_in_errors(
         MESSAGES['required']['required'],
         err.value.detail,
-        'parent.parent.parent.parent.parent.required',
+        'parent.parent.parent.parent.required.parent',
     )
 
 

--- a/tests/validation/schema/test_required_validation.py
+++ b/tests/validation/schema/test_required_validation.py
@@ -6,34 +6,64 @@ from flex.exceptions import (
 from flex.error_messages import (
     MESSAGES,
 )
-from flex.constants import EMPTY
+from flex.constants import (
+    OBJECT,
+)
 
 from tests.utils import (
     generate_validator_from_schema,
-    assert_error_message_equal,
+    assert_message_in_errors,
+    assert_message_not_in_errors,
+    assert_path_not_in_errors,
 )
 
 
 def test_field_declared_as_required():
     schema = {
-        'required': True,
+        'type': OBJECT,
+        'required': [
+            'field-A',
+            # 'field-B',
+        ],
     }
     validator = generate_validator_from_schema(schema)
 
     with pytest.raises(ValidationError) as err:
-        validator(EMPTY)
+        validator({})
 
-    assert 'required' in err.value.messages[0]
-    assert_error_message_equal(
-        err.value.messages[0]['required'][0],
+    assert_message_in_errors(
         MESSAGES['required']['required'],
+        err.value.detail,
+        'required.field-A',
+    )
+    assert_path_not_in_errors(
+        'required.field-B',
+        err.value.detail,
     )
 
 
 def test_field_declared_as_required_with_field_present_is_valid():
     schema = {
-        'required': True,
+        'type': OBJECT,
+        'required': [
+            'field-A',
+            # 'field-B',
+        ],
     }
     validator = generate_validator_from_schema(schema)
 
-    validator('John Smith')
+    try:
+        validator({'field-A': 'present'})
+    except ValidationError as err:
+        errors = err.detail
+    else:
+        errors = {}
+
+    assert_path_not_in_errors(
+        'required.field-A',
+        errors,
+    )
+    assert_path_not_in_errors(
+        'required.field-B',
+        errors,
+    )


### PR DESCRIPTION
### What is the problem / feature ?

Flex was expecting the following usage of the `required` keyword argument for schema objects.

```yaml
Pet:
    properties:
      id:
        type: integer
        required: true
        format: int64
      name:
        type: string
        required: true
```


### How did it get fixed / implemented ?

Changed the handling to match the 
[json schema required spec](http://json-schema.org/latest/json-schema-validation.html#anchor61)

> The value of this keyword MUST be an array. This array MUST have at least one element. Elements of this array MUST be strings, and MUST be unique.

```yaml
Pet:
    required:
      - id
      - name
    properties:
      id:
        type: integer
        format: int64
      name:
        type: string
```
### How can someone test / see it ?

See that usage of the `required` keyword as a list of field names validates correctly.

*Here is a cute animal picture for your troubles...*

![7a410e8a03c5595c74e0036d0dda1e71](https://cloud.githubusercontent.com/assets/824194/6587283/ebd2e750-c747-11e4-8c00-9ccddb94f3ec.jpg)
