### PR TITLE
Further improvements to path matching

### DIFF
--- a/flex/paths.py
+++ b/flex/paths.py
@@ -151,18 +151,18 @@ def match_path_to_api_path(path_definitions, target_path, base_path='', global_p
         raise LookupError(MESSAGES['path']['no_matching_paths_found'].format(target_path))
     elif len(matching_api_paths) > 1:
         # TODO: This area needs improved logic.
-        # We check to see if any of the matches has more matched groups than
+        # We check to see if any of the matched paths is longers than
         # the others.  If so, we *assume* it is the correct match.  This is
         # going to be prone to false positives. in certain cases.
-        matches_by_group_size = collections.defaultdict(list)
+        matches_by_path_size = collections.defaultdict(list)
         for path, match in matching_api_paths:
-            matches_by_group_size[len(match.groups())].append(path)
-        longest_match = max(matches_by_group_size.keys())
-        if len(matches_by_group_size[longest_match]) == 1:
-            return matches_by_group_size[longest_match][0]
+            matches_by_path_size[len(path)].append(path)
+        longest_match = max(matches_by_path_size.keys())
+        if len(matches_by_path_size[longest_match]) == 1:
+            return matches_by_path_size[longest_match][0]
         raise MultiplePathsFound(
             MESSAGES['path']['multiple_paths_found'].format(
-                [v[0] for v in matching_api_paths]
+                target_path, [v[0] for v in matching_api_paths],
             )
         )
     else:

--- a/tests/core/test_match_request_path_to_api_path.py
+++ b/tests/core/test_match_request_path_to_api_path.py
@@ -208,7 +208,8 @@ def test_matching_with_nested_path():
     )
     assert path == '/get/{id}/nested/{other_id}'
 
-def test_matching_with_full_nested_path():
+
+def test_matching_with_full_nested_parametrized_resource():
     schema = SchemaFactory(
         paths={
             '/get/main/':{
@@ -251,3 +252,42 @@ def test_matching_with_full_nested_path():
         target_path='/get/main/1234/nested/5678',
     )
     assert path == '/get/main/{id}/nested/{other_id}'
+
+
+def test_matching_with_full_nested_list_resource():
+    schema = SchemaFactory(
+        paths={
+            '/get/main/':{
+                'get':{},
+            },
+            '/get/main/{id}': {
+                'get': {
+                    'parameters': [{
+                        'name': 'id',
+                        'in': PATH,
+                        'type': STRING,
+                        'required': True,
+                    }],
+                },
+            },
+            '/get/main/{id}/nested/': {
+                'get': {
+                    'parameters': [
+                        {
+                            'name': 'id',
+                            'in': PATH,
+                            'type': STRING,
+                            'required': True,
+                        },
+                    ],
+                },
+            },
+        },
+    )
+    paths = schema['paths']
+
+    path = match_path_to_api_path(
+        path_definitions=paths,
+        target_path='/get/main/1234/nested/',
+    )
+    assert path == '/get/main/{id}/nested/'


### PR DESCRIPTION
cc @alvarocavalcanti

### What is the problem / feature ?

Trying to match the path `/v1/accounts/23` against a schema with the following paths throws an error.

```
paths:
    - "/v1/accounts/{account_id}"
    - "/v1/accounts/{account_id}/subscriptions"
```

### How did it get fixed / implemented ?

Changed the logic around picking from multiple matches to choose the longest api path.  This doesn't actually fix #58 but it still improves the situation.

### How can someone test / see it ?

Match the path `/v1/accounts/23` against a schema with the following paths and see that it matches the `/subscriptions` one correctly.

```
paths:
    - "/v1/accounts/{account_id}"
    - "/v1/accounts/{account_id}/subscriptions"
```

*Here is a cute animal picture for your troubles...*

![tumblr_n85i8amqlh1s8mgkyo1_500](https://cloud.githubusercontent.com/assets/824194/6869122/3330aa58-d457-11e4-92cb-50800dbdd1e9.jpg)

