### PR TITLE
Add request body parameter validation 

### DIFF
--- a/flex/http.py
+++ b/flex/http.py
@@ -48,8 +48,10 @@ class Request(URLMixin):
         TODO: What is the right way to do this?
         """
         if not self.body:
-            return None
-        if self.content_type == 'application/json':
+            return self.body
+        elif self.body is EMPTY:
+            return EMPTY
+        elif self.content_type == 'application/json':
             return json.loads(self.body)
         else:
             raise NotImplementedError("No parser for content type")

--- a/flex/http.py
+++ b/flex/http.py
@@ -42,6 +42,18 @@ class Request(URLMixin):
         self.content_type = content_type
         self.headers = headers or {}
 
+    @property
+    def data(self):
+        """
+        TODO: What is the right way to do this?
+        """
+        if not self.body:
+            return None
+        if self.content_type == 'application/json':
+            return json.loads(self.body)
+        else:
+            raise NotImplementedError("No parser for content type")
+
 
 def _normalize_requests_request(request):
     import requests

--- a/flex/validation/operation.py
+++ b/flex/validation/operation.py
@@ -167,14 +167,14 @@ def generate_parameters_validator(api_path, path_definition, parameters,
     )
 
     # FORM_DATA
-    #in_form_data_parameters = filter_parameters(all_parameters, in_=FORM_DATA)
-    #validators.add_validator(
-    #    'form_data',
-    #    chain_reduce_partial(
-    #        operator.attrgetter('data'),
-    #        generate_form_data_validator(in_form_data_parameters, context),
-    #    )
-    #)
+    # in_form_data_parameters = filter_parameters(all_parameters, in_=FORM_DATA)
+    # validators.add_validator(
+    #     'form_data',
+    #     chain_reduce_partial(
+    #         operator.attrgetter('data'),
+    #         generate_form_data_validator(in_form_data_parameters, context),
+    #     )
+    # )
 
     # REQUEST_BODY
     in_request_body_parameters = filter_parameters(all_parameters, in_=BODY)

--- a/flex/validation/operation.py
+++ b/flex/validation/operation.py
@@ -12,7 +12,6 @@ from flex.constants import (
     QUERY,
     PATH,
     HEADER,
-    FORM_DATA,
     BODY,
 )
 from flex.parameters import (

--- a/flex/validation/operation.py
+++ b/flex/validation/operation.py
@@ -31,6 +31,7 @@ from flex.validation.path import (
     generate_path_parameters_validator,
 )
 from flex.validation.common import (
+    noop,
     generate_value_processor,
     generate_object_validator,
 )
@@ -94,6 +95,8 @@ def generate_form_data_validator(form_data_parameters, context, **kwargs):
 def generate_request_body_validator(body_parameters, context, **kwargs):
     if len(body_parameters) > 1:
         raise ValueError("Too many body parameters.  Should only be one")
+    elif not body_parameters:
+        return noop
     body_validators = construct_parameter_validators(
         body_parameters[0], context=context,
     )

--- a/flex/validation/operation.py
+++ b/flex/validation/operation.py
@@ -22,6 +22,7 @@ from flex.parameters import (
 )
 from flex.validation.parameter import (
     validate_query_parameters,
+    construct_parameter_validators,
 )
 from flex.validation.header import (
     construct_header_validators,
@@ -91,7 +92,12 @@ def generate_form_data_validator(form_data_parameters, context, **kwargs):
 
 
 def generate_request_body_validator(body_parameters, context, **kwargs):
-    pass
+    if len(body_parameters) > 1:
+        raise ValueError("Too many body parameters.  Should only be one")
+    body_validators = construct_parameter_validators(
+        body_parameters[0], context=context,
+    )
+    return generate_object_validator(field_validators=body_validators)
 
 
 def generate_parameters_validator(api_path, path_definition, parameters,
@@ -158,14 +164,14 @@ def generate_parameters_validator(api_path, path_definition, parameters,
     )
 
     # FORM_DATA
-    in_form_data_parameters = filter_parameters(all_parameters, in_=FORM_DATA)
-    validators.add_validator(
-        'form_data',
-        chain_reduce_partial(
-            operator.attrgetter('data'),
-            generate_form_data_validator(in_form_data_parameters, context),
-        )
-    )
+    #in_form_data_parameters = filter_parameters(all_parameters, in_=FORM_DATA)
+    #validators.add_validator(
+    #    'form_data',
+    #    chain_reduce_partial(
+    #        operator.attrgetter('data'),
+    #        generate_form_data_validator(in_form_data_parameters, context),
+    #    )
+    #)
 
     # REQUEST_BODY
     in_request_body_parameters = filter_parameters(all_parameters, in_=BODY)

--- a/flex/validation/operation.py
+++ b/flex/validation/operation.py
@@ -12,6 +12,8 @@ from flex.constants import (
     QUERY,
     PATH,
     HEADER,
+    FORM_DATA,
+    BODY,
 )
 from flex.parameters import (
     filter_parameters,
@@ -84,6 +86,14 @@ def generate_header_validator(headers, context, **kwargs):
     return generate_object_validator(field_validators=validators)
 
 
+def generate_form_data_validator(form_data_parameters, context, **kwargs):
+    pass
+
+
+def generate_request_body_validator(body_parameters, context, **kwargs):
+    pass
+
+
 def generate_parameters_validator(api_path, path_definition, parameters,
                                   context, **kwargs):
     """
@@ -145,6 +155,26 @@ def generate_parameters_validator(api_path, path_definition, parameters,
             operator.attrgetter('headers'),
             generate_header_validator(in_header_parameters, context),
         ),
+    )
+
+    # FORM_DATA
+    in_form_data_parameters = filter_parameters(all_parameters, in_=FORM_DATA)
+    validators.add_validator(
+        'form_data',
+        chain_reduce_partial(
+            operator.attrgetter('data'),
+            generate_form_data_validator(in_form_data_parameters, context),
+        )
+    )
+
+    # REQUEST_BODY
+    in_request_body_parameters = filter_parameters(all_parameters, in_=BODY)
+    validators.add_validator(
+        'request_body',
+        chain_reduce_partial(
+            operator.attrgetter('data'),
+            generate_request_body_validator(in_request_body_parameters, context),
+        )
     )
 
     return generate_object_validator(field_validators=validators)

--- a/tests/core/test_example_schemas.py
+++ b/tests/core/test_example_schemas.py
@@ -9,10 +9,10 @@ DIR = os.path.dirname(os.path.abspath(__file__))
 @pytest.mark.parametrize(
     'path',
     (
-        pytest.mark.xfail(os.path.join(DIR, 'example_schemas/uber.yaml')),
+        os.path.join(DIR, 'example_schemas/uber.yaml'),
         pytest.mark.xfail(os.path.join(DIR, 'example_schemas/petstore.yaml')),
         pytest.mark.xfail(os.path.join(DIR, 'example_schemas/petstore-expanded.yaml')),
-        pytest.mark.xfail(os.path.join(DIR, 'example_schemas/api-with-examples.yaml')),
+        os.path.join(DIR, 'example_schemas/api-with-examples.yaml'),
     )
 )
 def test_load_and_parse_schema(path):

--- a/tests/core/test_format_validators.py
+++ b/tests/core/test_format_validators.py
@@ -50,7 +50,7 @@ def test_date_time_format_validator_detects_invalid_values(value):
         # Leap second should be valid but iso8601 doesn't correctly parse.
         pytest.mark.xfail('1990-12-31T15:59:60-08:00'),
         # Weird netherlands time from strange 1909 law.
-        pytest.mark.xfail('1937-01-01T12:00:27.87+00:20'),
+        '1937-01-01T12:00:27.87+00:20',
     )
 )
 def test_date_time_format_validator_with_valid_dateties(value):

--- a/tests/http/test_request_data_property.py
+++ b/tests/http/test_request_data_property.py
@@ -1,0 +1,39 @@
+import pytest
+import json
+
+from flex.constants import EMPTY
+
+from tests.factories import (
+    RequestFactory,
+)
+
+def test_null_body_returns_null():
+    request = RequestFactory(body=None)
+    assert request.data is None
+
+
+def test_empty_string_body_returns_empty_string():
+    request = RequestFactory(body='')
+    assert request.data == ''
+
+
+def test_empty_body_returns_empty():
+    request = RequestFactory(body=EMPTY)
+    assert request.data is EMPTY
+
+
+def test_json_content_type_with_json_body():
+    request = RequestFactory(
+        body=json.dumps({'key': 'value'}),
+        content_type='application/json',
+    )
+    assert request.data == {'key': 'value'}
+
+
+def test_unsupported_content_type():
+    request = RequestFactory(
+        body=json.dumps({'key': 'value'}),
+        content_type='application/unsupported',
+    )
+    with pytest.raises(NotImplementedError):
+        request.data

--- a/tests/validation/request/test_request_body_parameter_validation.py
+++ b/tests/validation/request/test_request_body_parameter_validation.py
@@ -1,0 +1,72 @@
+import json
+
+import pytest
+
+from flex.validation.request import (
+    validate_request,
+)
+from flex.error_messages import MESSAGES
+from flex.constants import (
+    PATH,
+    QUERY,
+    STRING,
+    INTEGER,
+    BODY,
+    POST,
+    OBJECT,
+)
+
+from tests.factories import (
+    SchemaFactory,
+    RequestFactory,
+)
+from tests.utils import assert_message_in_errors
+
+
+@pytest.fixture
+def user_post_schema():
+    schema = SchemaFactory(
+        parameters = {
+            'user': {
+                'name': 'user',
+                'in': BODY,
+                'description': 'user',
+                'required': True,
+                'schema': {
+                    'type': OBJECT,
+                    'properties': {
+                        'username': {'type': STRING},
+                        'email': {'type': STRING, 'format': 'email'},
+                    },
+                },
+            },
+        },
+        paths={
+            '/post/': {
+                'parameters': [
+                    'user',
+                ],
+                'post': {
+                    'responses': {200: {'description': "Success"}},
+                },
+            },
+        },
+    )
+    return schema
+
+
+def test_request_body_parameter_validation_with_no_declared_parameters(user_post_schema):
+    """
+    Test validating the request body with a valid post.
+    """
+    request = RequestFactory(
+        url='http://www.example.com/post/',
+        content_type='application/json',
+        body=json.dumps({'username': 'Test User', 'email': 'test@example.com'}),
+        method=POST,
+    )
+
+    validate_request(
+        request=request,
+        schema=user_post_schema,
+    )

--- a/tests/validation/request/test_request_body_parameter_validation.py
+++ b/tests/validation/request/test_request_body_parameter_validation.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 
+from flex.exceptions import ValidationError
 from flex.validation.request import (
     validate_request,
 )
@@ -55,7 +56,7 @@ def user_post_schema():
     return schema
 
 
-def test_request_body_parameter_validation_with_no_declared_parameters(user_post_schema):
+def test_request_body_parameter_validation_with_valid_value(user_post_schema):
     """
     Test validating the request body with a valid post.
     """
@@ -69,4 +70,27 @@ def test_request_body_parameter_validation_with_no_declared_parameters(user_post
     validate_request(
         request=request,
         schema=user_post_schema,
+    )
+
+
+def test_request_body_parameter_validation_with_invalid_value(user_post_schema):
+    """
+    Test validating the request body with a valid post.
+    """
+    request = RequestFactory(
+        url='http://www.example.com/post/',
+        content_type='application/json',
+        body=json.dumps({'username': 'Test User', 'email': 'test'}),
+        method=POST,
+    )
+
+    with pytest.raises(ValidationError) as err:
+        validate_request(
+            request=request,
+            schema=user_post_schema,
+        )
+
+    assert_message_in_errors(
+        MESSAGES['format']['invalid_email'],
+        err.value.detail,
     )


### PR DESCRIPTION
Stub.

will fix #9

> Body - The payload that's appended to the HTTP request. Since there can only be one payload, there can only be one body parameter. The name of the body parameter has no effect on the parameter itself and is used for documentation purposes only. Since Form parameters are also in the payload, body and form parameters cannot exist together for the same operation.

Not sure how much of this should be enforced by flex.