### PR TITLE
Fixes #68 - default keyword was not loaded correctly

### DIFF
--- a/flex/loading/common/single_parameter/__init__.py
+++ b/flex/loading/common/single_parameter/__init__.py
@@ -67,7 +67,7 @@ single_parameter_field_validators.add_property_validator(
 single_parameter_non_field_validators = ValidationDict()
 single_parameter_non_field_validators.update(common_non_field_validators)
 single_parameter_non_field_validators.update(common_type_validators)
-single_parameter_non_field_validators.add_property_validator(
+single_parameter_non_field_validators.add_validator(
     'default', validate_default_is_of_one_of_declared_types,
 )
 single_parameter_non_field_validators.add_validator(

--- a/tests/loading/definition/parameters/single/test_default_validation.py
+++ b/tests/loading/definition/parameters/single/test_default_validation.py
@@ -1,0 +1,47 @@
+import pytest
+
+from flex.error_messages import MESSAGES
+from flex.exceptions import ValidationError
+from flex.loading.definitions.parameters import (
+    single_parameter_validator,
+)
+
+from tests.factories import ParameterFactory
+from tests.utils import (
+    assert_path_not_in_errors,
+    assert_message_in_errors,
+)
+
+
+def test_default_is_not_required():
+    context = {'deferred_references': set()}
+    parameter = ParameterFactory()
+    assert 'default' not in parameter
+    try:
+        single_parameter_validator(parameter, context=context)
+    except ValidationError as err:
+        errors = err.detail
+    else:
+        errors = {}
+
+    assert_path_not_in_errors(
+        'default',
+        errors
+    )
+
+
+def test_parameter_validation_with_default_present():
+    context = {'deferred_references': set()}
+    parameter = ParameterFactory(default='0')
+    assert 'default' in parameter
+    try:
+        single_parameter_validator(parameter, context=context)
+    except ValidationError as err:
+        errors = err.detail
+    else:
+        errors = {}
+
+    assert_path_not_in_errors(
+        'default',
+        errors
+    )


### PR DESCRIPTION
cc @MattiSG

### What is the problem / feature ?

The validator for the `default` keyword was being loaded onto the single parameter validator as a property validator rather than a field validator.  Since property validators try to pull a key off of an object, this threw an attribute error.

### How did it get fixed / implemented ?

Fixed how the type validation for the default keyword was loaded onto the single parameter validation.

### How can someone test / see it ?

Try to validate the following schema.

```bash
$ flex --source http://openfisca.sgmap.fr/api/1/swagger
```

*Here is a cute animal picture for your troubles...*

![persian-cat-wearing-straw-hat-gk-hartvikki-hart](https://cloud.githubusercontent.com/assets/824194/6967728/60c9544e-d91e-11e4-89cb-7aa7544651aa.jpg)


