### PR TITLE
Fix external docs validation

### DIFF
--- a/flex/formats.py
+++ b/flex/formats.py
@@ -74,7 +74,11 @@ register = registry.register
 
 @register(URI, STRING)
 def uri_validator(value, **kwargs):
-    parts = rfc3987.parse(value, rule='URI')
+    try:
+        parts = rfc3987.parse(value, rule='URI')
+    except ValueError:
+        raise ValidationError(MESSAGES['format']['invalid_uri'].format(value))
+
     if not parts['scheme'] or not parts['authority']:
         raise ValidationError(MESSAGES['format']['invalid_uri'].format(value))
 

--- a/flex/loading/common/external_docs.py
+++ b/flex/loading/common/external_docs.py
@@ -1,0 +1,28 @@
+from flex.constants import (
+    OBJECT,
+    URI,
+    STRING,
+)
+from flex.validation.common import (
+    generate_object_validator,
+)
+
+
+external_docs_schema = {
+    'type': OBJECT,
+    'required': [
+        'url',
+    ],
+    'properties': {
+        'description': {
+            'type': STRING,
+        },
+        'url': {
+            'type': STRING,
+            'format': URI,
+        },
+    },
+}
+external_docs_validator = generate_object_validator(
+    schema=external_docs_schema,
+)

--- a/flex/loading/common/schema/__init__.py
+++ b/flex/loading/common/schema/__init__.py
@@ -15,6 +15,9 @@ from .title import (
 from flex.loading.common.default import (
     validate_default_is_of_one_of_declared_types,
 )
+from flex.loading.common.external_docs import (
+    external_docs_validator,
+)
 from .min_properties import (
     min_properties_validator,
     validate_type_for_min_properties,
@@ -53,6 +56,7 @@ schema_field_validators.add_property_validator('maxProperties', max_properties_v
 schema_field_validators.add_property_validator('required', required_validator)
 schema_field_validators.add_property_validator('type', type_validator)
 schema_field_validators.add_property_validator('readOnly', read_only_validator)
+schema_field_validators.add_property_validator('externalDocs', external_docs_validator)
 
 schema_non_field_validators = ValidationDict()
 schema_non_field_validators.update(common_non_field_validators)

--- a/flex/loading/schema/paths/path_item/operation/__init__.py
+++ b/flex/loading/schema/paths/path_item/operation/__init__.py
@@ -13,6 +13,9 @@ from flex.validation.common import (
 from flex.loading.common.mimetypes import (
     mimetype_validator,
 )
+from flex.loading.common.external_docs import (
+    external_docs_validator,
+)
 from .parameters import (
     parameters_validator,
 )
@@ -34,9 +37,6 @@ operation_schema = {
             'type': STRING,
         },
         'description': {
-            'type': STRING,
-        },
-        'externalDocs': {
             'type': STRING,
         },
         'operationId': {
@@ -66,6 +66,7 @@ operation_schema = {
 field_validators = ValidationDict()
 field_validators.add_property_validator('parameters', parameters_validator)
 field_validators.add_property_validator('responses', responses_validator)
+field_validators.add_property_validator('externalDocs', external_docs_validator)
 
 non_field_validators = ValidationDict()
 non_field_validators.add_property_validator('consumes', mimetype_validator)

--- a/tests/loading/common/test_external_docs_validator.py
+++ b/tests/loading/common/test_external_docs_validator.py
@@ -1,0 +1,74 @@
+import pytest
+
+from flex.exceptions import ValidationError
+from flex.loading.common.external_docs import (
+    external_docs_validator,
+)
+
+
+@pytest.mark.parametrize(
+    'value',
+    (None, True, 1, 1.1, 'abc', [1, 2, 3]),
+)
+def test_external_docs_type_validation(value, MESSAGES, msg_assertions):
+    with pytest.raises(ValidationError) as err:
+        external_docs_validator(value)
+
+    msg_assertions.assert_message_in_errors(
+        MESSAGES['type']['invalid'],
+        err.value.detail,
+        'type',
+    )
+
+
+def test_external_docs_type_validation_with_correct_type(msg_assertions):
+    try:
+        external_docs_validator({})
+    except ValidationError as err:
+        errors = err.detail
+    else:
+        errors = {}
+
+    msg_assertions.assert_path_not_in_errors('type', errors)
+
+
+def test_description_keyword_is_not_required(msg_assertions):
+    try:
+        external_docs_validator({})
+    except ValidationError as err:
+        errors = err.detail
+    else:
+        errors = {}
+
+    msg_assertions.assert_path_not_in_errors('description', errors)
+
+
+def test_url_keyword_is_required(msg_assertions, MESSAGES):
+    with pytest.raises(ValidationError) as err:
+        external_docs_validator({})
+
+    msg_assertions.assert_message_in_errors(
+        MESSAGES['required']['required'],
+        err.value.detail,
+        'url',
+    )
+
+
+def test_url_keyword_must_be_a_uri_formatted(msg_assertions, MESSAGES):
+    with pytest.raises(ValidationError) as err:
+        external_docs_validator({
+            'url': 'not-a-valid-url',
+        })
+
+    msg_assertions.assert_message_in_errors(
+        MESSAGES['format']['invalid_uri'],
+        err.value.detail,
+        'url.format',
+    )
+
+
+def test_valid_external_docs_object(msg_assertions):
+    external_docs_validator({
+        'url': 'http://www.example.com',
+        'description': 'A test description',
+    })

--- a/tests/loading/schema/paths/operation/responses/schema/test_external_docs_validation.py
+++ b/tests/loading/schema/paths/operation/responses/schema/test_external_docs_validation.py
@@ -1,0 +1,45 @@
+import pytest
+
+from flex.exceptions import (
+    ValidationError,
+)
+from flex.loading.schema.paths.path_item.operation.responses.single.schema import (
+    schema_validator,
+)
+
+
+def test_external_docs_is_not_required(msg_assertions):
+    try:
+        schema_validator({})
+    except ValidationError as err:
+        errors = err.detail
+    else:
+        errors = {}
+
+    msg_assertions.assert_path_not_in_errors('externalDocs', errors)
+
+
+@pytest.mark.parametrize(
+    'value',
+    (None, True, 1, 1.1, 'abc', [1, 2, 3]),
+)
+def test_external_docs_type_validation(value, MESSAGES, msg_assertions):
+    with pytest.raises(ValidationError) as err:
+        schema_validator({'externalDocs': value})
+
+    msg_assertions.assert_message_in_errors(
+        MESSAGES['type']['invalid'],
+        err.value.detail,
+        'externalDocs.type',
+    )
+
+
+def test_external_docs_with_valid_value(msg_assertions):
+    try:
+        schema_validator({'consumes': {'url': 'http://example.com'}})
+    except ValidationError as err:
+        errors = err.detail
+    else:
+        errors = {}
+
+    msg_assertions.assert_path_not_in_errors('externalDocs', errors)

--- a/tests/loading/schema/paths/operation/test_external_docs_validation.py
+++ b/tests/loading/schema/paths/operation/test_external_docs_validation.py
@@ -1,0 +1,45 @@
+import pytest
+
+from flex.exceptions import (
+    ValidationError,
+)
+from flex.loading.schema.paths.path_item.operation import (
+    operation_validator,
+)
+
+
+def test_external_docs_is_not_required(msg_assertions):
+    try:
+        operation_validator({})
+    except ValidationError as err:
+        errors = err.detail
+    else:
+        errors = {}
+
+    msg_assertions.assert_path_not_in_errors('externalDocs', errors)
+
+
+@pytest.mark.parametrize(
+    'value',
+    (None, True, 1, 1.1, 'abc', [1, 2, 3]),
+)
+def test_external_docs_type_validation(value, MESSAGES, msg_assertions):
+    with pytest.raises(ValidationError) as err:
+        operation_validator({'externalDocs': value})
+
+    msg_assertions.assert_message_in_errors(
+        MESSAGES['type']['invalid'],
+        err.value.detail,
+        'externalDocs.type',
+    )
+
+
+def test_external_docs_with_valid_value(msg_assertions):
+    try:
+        operation_validator({'consumes': {'url': 'http://example.com'}})
+    except ValidationError as err:
+        errors = err.detail
+    else:
+        errors = {}
+
+    msg_assertions.assert_path_not_in_errors('externalDocs', errors)


### PR DESCRIPTION
### What is the problem / feature ?

The validation of the `externalDocs` keyword was incorrectly validating it as a string rather than the [`ExternalDocs`](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#external-documentation-object)

### How did it get fixed / implemented ?

Fixed it to be compliant with the swagger schema.

### How can someone test / see it ?

Validate a schema which declares external documentation objects.

*Here is a cute animal picture for your troubles...*
![dog-dog-cat-wearing-hamburger-shoes](https://cloud.githubusercontent.com/assets/824194/6968307/f63fddd2-d922-11e4-93d8-85fffb87ebf2.jpg)


