### PR TITLE
Remove the use of pip's internals

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+4.0.1
+-----
+
+- Remove the use of pip's internals in the setup.py file.
+
 4.0.0
 -----
 

--- a/flex/__init__.py
+++ b/flex/__init__.py
@@ -1,3 +1,3 @@
-VERSION = '4.0.0'
+VERSION = '4.0.1'
 
 from flex.core import load  # NOQA

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from pip.req import parse_requirements
-from pip.download import PipSession
 import os
 
 DIR = os.path.dirname(os.path.abspath(__file__))
@@ -11,13 +9,9 @@ try:
 except ImportError:
     from distutils.core import setup, find_packages
 
-version = '4.0.0'
+version = '4.0.1'
 
 readme = open(os.path.join(DIR, 'README.md')).read()
-
-requirements = [
-    str(req.req) for req in parse_requirements('requirements.txt', session=PipSession())
-]
 
 
 setup(
@@ -30,7 +24,16 @@ setup(
     url='https://github.com/pipermerriam/flex',
     include_package_data=True,
     py_modules=['flex'],
-    install_requires=requirements,
+    install_requires=[
+        "six>=1.7.3",
+        "PyYAML>=3.11",
+        "iso8601>=0.1.10",
+        "validate-email>=1.2",
+        "rfc3987>=1.3.4",
+        "requests>=2.4.3",
+        "click>=3.3",
+        "jsonpointer>=1.7",
+    ],
     license="BSD",
     zip_safe=False,
     entry_points={


### PR DESCRIPTION
The use of pips internals to parse the requirements.txt file is problematic.

![485837](https://cloud.githubusercontent.com/assets/824194/7213927/fcfd0a96-e54d-11e4-96e3-b14575cf6500.jpg)
