### PR TITLE
ewwww this is really gross

### DIFF
--- a/flex/exceptions.py
+++ b/flex/exceptions.py
@@ -18,7 +18,10 @@ class ErrorCollectionMixin(object):
             if not issubclass(type_, ValidationError):
                 return False
         if self:
-            raise ValidationError(self)
+            self.raise_()
+
+    def raise_(self):
+        raise ValidationError(self)
 
 
 class ErrorList(ErrorCollectionMixin, list):

--- a/flex/loading/common/reference.py
+++ b/flex/loading/common/reference.py
@@ -1,0 +1,59 @@
+from six.moves import urllib_parse as urlparse
+
+import jsonpointer
+
+from flex.exceptions import (
+    ValidationError,
+)
+from flex.datastructures import (
+    ValidationDict,
+)
+from flex.error_messages import MESSAGES
+from flex.constants import (
+    OBJECT,
+    STRING,
+)
+from flex.decorators import (
+    skip_if_not_of_type,
+)
+from flex.validation.common import (
+    generate_object_validator,
+)
+
+reference_object_schema = {
+    'type': OBJECT,
+    'additionalProperties': False,
+    'required': [
+        '$ref',
+    ],
+    'properties': {
+        '$ref': {
+            'type': STRING,
+        },
+    },
+}
+
+
+@skip_if_not_of_type(STRING)
+def validate_reference_pointer(reference, context, **kwargs):
+    parts = urlparse.urlparse(reference)
+    if any((parts.scheme, parts.netloc, parts.path, parts.params, parts.query)):
+        raise ValidationError(
+            MESSAGES['reference']['unsupported'].format(reference),
+        )
+
+    try:
+        jsonpointer.resolve_pointer(context, parts.fragment)
+    except jsonpointer.JsonPointerException:
+        raise ValidationError(
+            MESSAGES['reference']['undefined'].format(reference),
+        )
+
+
+non_field_validators = ValidationDict()
+non_field_validators.add_property_validator('$ref', validate_reference_pointer)
+
+reference_object_validator = generate_object_validator(
+    schema=reference_object_schema,
+    non_field_validators=non_field_validators,
+)

--- a/flex/loading/schema/paths/path_item/__init__.py
+++ b/flex/loading/schema/paths/path_item/__init__.py
@@ -10,10 +10,9 @@ from flex.validation.common import (
 from .operation import (
     operation_validator,
 )
-
-
-def parameters_validator(*args, **kwargs):
-    pass
+from .parameters import (
+    parameters_validator,
+)
 
 
 path_item_schema = {

--- a/flex/loading/schema/paths/path_item/operation/responses/__init__.py
+++ b/flex/loading/schema/paths/path_item/operation/responses/__init__.py
@@ -1,6 +1,7 @@
 import functools
 
 from flex.datastructures import (
+    ValidationDict,
     ValidationList,
 )
 from flex.constants import (
@@ -9,6 +10,12 @@ from flex.constants import (
 from flex.validation.common import (
     generate_object_validator,
     apply_validator_to_object,
+)
+from flex.validation.utils import (
+    generate_any_validator,
+)
+from flex.loading.common.reference import (
+    reference_object_validator,
 )
 from .single import (
     single_response_validator,
@@ -20,13 +27,31 @@ responses_schema = {
 }
 
 
+field_validators = ValidationDict()
+
+field_validators.add_property_validator(
+    'default',
+    generate_any_validator(
+        referenceObject=reference_object_validator,
+        responseObject=single_response_validator,
+    ),
+)
+
+
 non_field_validators = ValidationList()
 non_field_validators.add_validator(
-    functools.partial(apply_validator_to_object, validator=single_response_validator),
+    functools.partial(
+        apply_validator_to_object,
+        validator=generate_any_validator(
+            referenceObject=reference_object_validator,
+            responseObject=single_response_validator,
+        ),
+    )
 )
 
 
 responses_validator = generate_object_validator(
     schema=responses_schema,
+    field_validators=field_validators,
     non_field_validators=non_field_validators,
 )

--- a/flex/loading/schema/paths/path_item/parameters/__init__.py
+++ b/flex/loading/schema/paths/path_item/parameters/__init__.py
@@ -7,7 +7,7 @@ from flex.constants import (
 )
 from flex.validation.common import (
     generate_object_validator,
-    apply_validator_to_array,
+    apply_validator_to_object,
 )
 from flex.validation.utils import (
     generate_any_validator,
@@ -27,7 +27,7 @@ parameters_schema = {
 parameters_non_field_validators = ValidationList()
 parameters_non_field_validators.add_validator(
     functools.partial(
-        apply_validator_to_array,
+        apply_validator_to_object,
         validator=generate_any_validator(
             referenceObject=reference_object_validator,
             parameterObject=single_parameter_validator,

--- a/flex/loading/schema/paths/path_item/parameters/single.py
+++ b/flex/loading/schema/paths/path_item/parameters/single.py
@@ -1,0 +1,36 @@
+from flex.datastructures import (
+    ValidationDict,
+)
+from flex.loading.common.single_parameter import (
+    single_parameter_schema,
+    single_parameter_field_validators as common_single_parameter_field_validators,
+    single_parameter_non_field_validators as common_single_parameter_non_field_validators,
+)
+from flex.loading.schema.paths.path_item.operation.responses.single.schema import (
+    schema_validator,
+    items_validator,
+)
+from flex.validation.common import (
+    generate_object_validator,
+)
+
+
+single_parameter_field_validators = ValidationDict()
+single_parameter_field_validators.update(
+    common_single_parameter_field_validators
+)
+
+# schema fields
+single_parameter_field_validators.add_property_validator('schema', schema_validator)
+single_parameter_field_validators.add_property_validator('items', items_validator)
+
+single_parameter_non_field_validators = ValidationDict()
+single_parameter_non_field_validators.update(
+    common_single_parameter_non_field_validators
+)
+
+single_parameter_validator = generate_object_validator(
+    schema=single_parameter_schema,
+    field_validators=single_parameter_field_validators,
+    non_field_validators=single_parameter_non_field_validators,
+)

--- a/flex/parameters.py
+++ b/flex/parameters.py
@@ -1,6 +1,5 @@
-import collections
-
 from flex.decorators import rewrite_reserved_words
+from flex.utils import dereference_reference
 
 
 @rewrite_reserved_words
@@ -44,8 +43,10 @@ def merge_parameter_lists(*parameter_definitions):
     return merged_parameters.values()
 
 
-def dereference_parameter_list(parameters, parameter_definitions):
-    return [
-        (p if isinstance(p, collections.Mapping) else parameter_definitions[p])
+def dereference_parameter_list(parameters, context):
+    return tuple((
+        dereference_reference(p['$ref'], context)
+        if '$ref' in p
+        else p
         for p in parameters
-    ]
+    ))

--- a/flex/paths.py
+++ b/flex/paths.py
@@ -91,17 +91,18 @@ def path_to_pattern(api_path, parameters):
     return pattern
 
 
-def path_to_regex(api_path, path_parameters, operation_parameters=None, global_parameters=None):
-    if global_parameters is None:
-        global_parameters = {}
+def path_to_regex(api_path, path_parameters, operation_parameters=None,
+                  context=None):
+    if context is None:
+        context = {}
     if operation_parameters is None:
         operation_parameters = []
     pattern = path_to_pattern(
         api_path=api_path,
         parameters=merge_parameter_lists(
-            global_parameters.values(),
-            dereference_parameter_list(path_parameters, global_parameters),
-            dereference_parameter_list(operation_parameters, global_parameters),
+            context.get('parameters', {}).values(),
+            dereference_parameter_list(path_parameters, context),
+            dereference_parameter_list(operation_parameters, context),
         ),
     )
     return re.compile(pattern)
@@ -121,15 +122,15 @@ def extract_operation_parameters(path_definition):
     ))
 
 
-def match_path_to_api_path(path_definitions, target_path, base_path='', global_parameters=None):
+def match_path_to_api_path(path_definitions, target_path, base_path='', context=None):
     """
     Match a request or response path to one of the api paths.
 
     Anything other than exactly one match is an error condition.
     """
-    if global_parameters is None:
-        global_parameters = {}
-    assert isinstance(global_parameters, collections.Mapping)
+    if context is None:
+        context = {}
+    assert isinstance(context, collections.Mapping)
     if target_path.startswith(base_path):
         target_path = target_path[len(base_path):]
 
@@ -139,7 +140,7 @@ def match_path_to_api_path(path_definitions, target_path, base_path='', global_p
             api_path=p,
             path_parameters=extract_path_parameters(v),
             operation_parameters=extract_operation_parameters(v),
-            global_parameters=global_parameters,
+            context=context,
         )
         for p, v in path_definitions.items()
     }

--- a/flex/utils.py
+++ b/flex/utils.py
@@ -2,7 +2,10 @@ import math
 import collections
 import numbers
 
+from six.moves import urllib_parse as urlparse
 import six
+
+import jsonpointer
 
 from flex.constants import (
     PRIMATIVE_TYPES,
@@ -16,6 +19,7 @@ from flex.constants import (
     TRUE_VALUES,
     FALSE_VALUES,
 )
+from flex.error_messages import MESSAGES
 
 from flex.functional import chain_reduce_partial as _chain_reduce_partial
 
@@ -186,3 +190,12 @@ def format_errors(errors, indent=0, prefix='', suffix=''):
 
 def prettify_errors(errors):
     return '\n'.join(format_errors(errors))
+
+
+def dereference_reference(reference, context):
+    parts = urlparse.urlparse(reference)
+    if any((parts.scheme, parts.netloc, parts.path, parts.params, parts.query)):
+        raise ValueError(
+            MESSAGES['reference']['unsupported'].format(reference),
+        )
+    return jsonpointer.resolve_pointer(context, parts.fragment)

--- a/flex/validation/common.py
+++ b/flex/validation/common.py
@@ -430,18 +430,18 @@ def validate_request_method_to_operation(request_method, path_definition):
     return operation_definition
 
 
-def validate_path_to_api_path(path, paths, basePath='', parameters=None, **kwargs):
+def validate_path_to_api_path(path, paths, basePath='', context=None, **kwargs):
     """
     Given a path, find the api_path it matches.
     """
-    if parameters is None:
-        parameters = {}
+    if context is None:
+        context = {}
     try:
         api_path = match_path_to_api_path(
             path_definitions=paths,
             target_path=path,
             base_path=basePath,
-            global_parameters=parameters,
+            context=context,
         )
     except LookupError as err:
         raise ValidationError(str(err))

--- a/flex/validation/operation.py
+++ b/flex/validation/operation.py
@@ -116,14 +116,13 @@ def generate_parameters_validator(api_path, path_definition, parameters,
     # TODO: figure out how to merge this with the same code in response
     # validation.
     validators = ValidationDict()
-    parameter_definitions = context.get('parameters', {})
     path_level_parameters = dereference_parameter_list(
         path_definition.get('parameters', []),
-        parameter_definitions,
+        context,
     )
     operation_level_parameters = dereference_parameter_list(
         parameters,
-        parameter_definitions,
+        context,
     )
 
     all_parameters = merge_parameter_lists(

--- a/flex/validation/parameter.py
+++ b/flex/validation/parameter.py
@@ -3,6 +3,9 @@ from flex.utils import is_non_string_iterable
 from flex.exceptions import ValidationError
 from flex.error_messages import MESSAGES
 from flex.context_managers import ErrorCollection
+from flex.validation.reference import (
+    LazyReferenceValidator,
+)
 from flex.validation.common import (
     noop,
     generate_type_validator,
@@ -102,6 +105,10 @@ def construct_parameter_validators(parameter, context):
     definition.
     """
     validators = ValidationDict()
+    if '$ref' in parameter:
+        validators.add_validator(
+            '$ref', ParameterReferenceValidator(parameter['$ref'], context),
+        )
     for key in parameter:
         if key in validator_mapping:
             validators.add_validator(
@@ -151,3 +158,7 @@ def construct_multi_parameter_validators(parameters, context):
         )
 
     return validators
+
+
+class ParameterReferenceValidator(LazyReferenceValidator):
+    validators_constructor = construct_parameter_validators

--- a/flex/validation/reference.py
+++ b/flex/validation/reference.py
@@ -1,0 +1,53 @@
+from six.moves import urllib_parse as urlparse
+
+import jsonpointer
+
+from flex.validation.common import (
+    validate_object,
+)
+
+
+class LazyReferenceValidator(object):
+    """
+    This class acts as a lazy validator for references in schemas to prevent an
+    infinite recursion error when a schema references itself, or there is a
+    reference loop between more than one schema.
+
+    The validator is only constructed if validator is needed.
+    """
+    validators_constructor = None
+
+    def __init__(self, reference, context):
+        if self.validators_constructor is None:
+            raise NotImplementedError(
+                "Subclasses of LazyReferenceValidator must specify a "
+                "`validators_constructor` function"
+            )
+
+        self.reference_fragment = urlparse.urlparse(reference).fragment
+        # TODO: something better than this which potentiall raises a
+        # JsonPointerException
+        jsonpointer.resolve_pointer(context, self.reference_fragment)
+        self.reference = reference
+        self.context = context
+
+    def __call__(self, value, **kwargs):
+        return validate_object(
+            value,
+            schema=self.schema,
+            **kwargs
+        )
+
+    @property
+    def schema(self):
+        return jsonpointer.resolve_pointer(self.context, self.reference_fragment)
+
+    @property
+    def validators(self):
+        return self.validators_constructor(
+            self.schema,
+            self.context,
+        )
+
+    def items(self):
+        return self.validators.items()

--- a/flex/validation/request.py
+++ b/flex/validation/request.py
@@ -24,6 +24,7 @@ def validate_request(request, schema):
         try:
             api_path = validate_path_to_api_path(
                 path=request.path,
+                context=schema,
                 **schema
             )
         except ValidationError as err:

--- a/flex/validation/response.py
+++ b/flex/validation/response.py
@@ -114,14 +114,13 @@ def generate_path_validator(api_path, path_definition, parameters,
     """
     Generates a callable for validating the parameters in a response object.
     """
-    global_parameters = context.get('parameters', {})
     path_level_parameters = dereference_parameter_list(
         path_definition.get('parameters', []),
-        global_parameters,
+        context,
     )
     operation_level_parameters = dereference_parameter_list(
         parameters,
-        global_parameters,
+        context,
     )
 
     all_parameters = merge_parameter_lists(
@@ -202,6 +201,7 @@ def validate_response(response, request_method, schema):
         try:
             api_path = validate_path_to_api_path(
                 path=response.path,
+                context=schema,
                 **schema
             )
         except ValidationError as err:

--- a/flex/validation/utils.py
+++ b/flex/validation/utils.py
@@ -1,0 +1,43 @@
+import functools
+
+from flex.exceptions import (
+    ValidationError,
+    ErrorDict,
+)
+
+
+def any_validator(obj, validators, **kwargs):
+    """
+    Attempt multiple validators on an object.
+
+    - If any pass, then all validation passes.
+    - Otherwise, raise all of the errors.
+    """
+    if not len(validators) > 1:
+        raise ValueError(
+            "any_validator requires at least 2 validator.  Only got "
+            "{0}".format(len(validators))
+        )
+    errors = ErrorDict()
+    for key, validator in validators.items():
+        try:
+            validator(obj, **kwargs)
+        except ValidationError as err:
+            errors[key] = err.detail
+        else:
+            break
+    else:
+        if len(errors) == 1:
+            # Special case for a single error.  Just raise it as if it was the
+            # only validator run.
+            error = errors.values()[0]
+            raise ValidationError(error)
+        else:
+            # Raise all of the errors with the key namespaces.
+            errors.raise_()
+
+
+def generate_any_validator(**validators):
+    return functools.partial(
+        any_validator, validators=validators,
+    )

--- a/tests/loading/common/test_reference_object_validation.py
+++ b/tests/loading/common/test_reference_object_validation.py
@@ -1,0 +1,71 @@
+import pytest
+
+from flex.constants import (
+    STRING,
+)
+from flex.error_messages import MESSAGES
+from flex.exceptions import ValidationError
+
+from tests.utils import (
+    assert_message_in_errors,
+    assert_path_not_in_errors,
+)
+
+from flex.loading.common.reference import (
+    reference_object_validator,
+)
+
+
+
+
+def test_ref_is_required():
+    ref_schema = {}
+
+    with pytest.raises(ValidationError) as err:
+        reference_object_validator(ref_schema)
+
+    assert_message_in_errors(
+        MESSAGES['required']['required'],
+        err.value.detail,
+        'required.$ref',
+    )
+
+
+@pytest.mark.parametrize(
+    'value',
+    ({'a': 'abc'}, 1, 1.1, True, ['a', 'b'], None),
+)
+def test_ref_with_invalid_types(value):
+    schema = {'$ref': value}
+
+    with pytest.raises(ValidationError) as err:
+        reference_object_validator(schema)
+
+    assert_message_in_errors(
+        MESSAGES['type']['invalid'],
+        err.value.detail,
+        '$ref.type',
+    )
+
+
+def test_valid_reference():
+    schema = {'$ref': '#/definitions/SomeReference'}
+    context = {
+        'definitions': {
+            'SomeReference': {
+                'type': STRING,
+            }
+        }
+    }
+
+    try:
+        reference_object_validator(schema, context=context)
+    except ValidationError as err:
+        errors = err.detail
+    else:
+        errors = {}
+
+    assert_path_not_in_errors(
+        '$ref',
+        errors,
+    )

--- a/tests/loading/schema/paths/operation/responses/test_response_validation.py
+++ b/tests/loading/schema/paths/operation/responses/test_response_validation.py
@@ -1,0 +1,89 @@
+import pytest
+
+from flex.error_messages import MESSAGES
+from flex.exceptions import (
+    ValidationError,
+)
+from flex.loading.schema.paths.path_item.operation.responses import (
+    responses_validator,
+)
+
+
+def test_description_is_required(msg_assertions):
+    with pytest.raises(ValidationError) as err:
+        responses_validator({
+            200: {},
+        })
+
+    msg_assertions.assert_message_in_errors(
+        MESSAGES['required']['required'],
+        err.value.detail,
+        '200.required.description',
+    )
+
+
+def test_response_as_reference_missing_description(msg_assertions):
+    responses = {
+        200: {
+            '$ref': '#/responses/SomeResponse'
+        },
+    }
+    context = {
+        'responses': {
+            'SomeResponse': {},
+        },
+    }
+    try:
+        responses_validator(responses, context=context)
+    except ValidationError as err:
+        errors = err.detail
+    else:
+        errors = {}
+
+    msg_assertions.assert_path_not_in_errors('200', errors)
+
+
+def test_with_description(msg_assertions):
+    try:
+        responses_validator({
+            200: {'description': 'A Description'},
+        })
+    except ValidationError as err:
+        errors = err.detail
+    else:
+        errors = {}
+
+    msg_assertions.assert_path_not_in_errors('200', errors)
+
+
+def test_with_description_in_reference(msg_assertions):
+    responses = {
+        200: {'$ref': '#/responses/SomeResponse'},
+    }
+    context = {
+        'responses': {
+            'SomeResponse': {'description': 'A Description'},
+        },
+    }
+    try:
+        responses_validator(responses, context=context)
+    except ValidationError as err:
+        errors = err.detail
+    else:
+        errors = {}
+
+    msg_assertions.assert_path_not_in_errors('200', errors)
+
+
+def test_with_missing_reference(msg_assertions):
+    responses = {
+        200: {'$ref': '#/responses/UnknownReference'},
+    }
+    with pytest.raises(ValidationError) as err:
+        responses_validator(responses, context={})
+
+    msg_assertions.assert_message_in_errors(
+        MESSAGES['reference']['undefined'],
+        err.value.detail,
+        '200.$ref',
+    )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -48,6 +48,12 @@ def assert_error_message_equal(formatted_msg, unformatted_msg):
         )
 
 
+def _compute_error_path(*values):
+    return '.'.join(
+        (six.text_type(value) for value in values)
+    ).strip('.')
+
+
 def _find_message_in_errors(message, errors, namespace=''):
     if isinstance(errors, six.string_types):
         if check_if_error_message_equal(errors, message):
@@ -57,7 +63,7 @@ def _find_message_in_errors(message, errors, namespace=''):
             for match in _find_message_in_errors(
                 message,
                 error,
-                '.'.join((namespace, key)).strip('.'),
+                _compute_error_path(namespace, key),
             ):
                 yield match
     elif isinstance(errors, list):
@@ -65,7 +71,7 @@ def _find_message_in_errors(message, errors, namespace=''):
             for match in _find_message_in_errors(
                 message,
                 error,
-                '.'.join((namespace, six.text_type(index))).strip('.'),
+                _compute_error_path(namespace, index),
             ):
                 yield match
     else:
@@ -78,8 +84,11 @@ def find_message_in_errors(*args, **kwargs):
 
 
 def _find_matching_paths(target_path, paths):
+    # paths with `.` in them.
     pattern = re.sub('\.', '.+', target_path)
+    # paths with a `^` not at the front
     pattern = re.sub(r'^(.+)\^', r'\1\^', pattern)
+    # paths with a `$` not at the end.
     pattern = re.sub(r'\$(.+)$', r'\$\1', pattern)
     for message_path in paths:
         if re.search(pattern, message_path):
@@ -120,14 +129,14 @@ def _enumerate_error_paths(errors, namespace=''):
         for key, error in errors.items():
             for match in _enumerate_error_paths(
                 error,
-                '.'.join((namespace, key)).strip('.'),
+                _compute_error_path(namespace, key),
             ):
                 yield match
     elif isinstance(errors, list):
         for index, error in enumerate(errors):
             for match in _enumerate_error_paths(
                 error,
-                '.'.join((namespace, six.text_type(index))).strip('.'),
+                _compute_error_path(namespace, index),
             ):
                 yield match
     else:

--- a/tests/validation/path/test_validate_path_to_api_path.py
+++ b/tests/validation/path/test_validate_path_to_api_path.py
@@ -26,6 +26,7 @@ def test_basic_request_path_validation():
     request = RequestFactory(url='http://www.example.com/get')
     path = validate_path_to_api_path(
         path=request.path,
+        context=context,
         **context
     )
     assert path == '/get'
@@ -50,6 +51,7 @@ def test_basic_request_path_validation_with_unspecified_paths(request_path):
     with pytest.raises(ValidationError) as err:
         validate_path_to_api_path(
             path=request.path,
+            context=context,
             **context
         )
 
@@ -72,6 +74,7 @@ def test_parametrized_string_path_validation():
     request = RequestFactory(url='http://www.example.com/get/25')
     path = validate_path_to_api_path(
         path=request.path,
+        context=context,
         **context
     )
     assert path == '/get/{id}'
@@ -90,6 +93,7 @@ def test_parametrized_integer_path_validation():
     request = RequestFactory(url='http://www.example.com/get/25')
     path = validate_path_to_api_path(
         path=request.path,
+        context=context,
         **context
     )
     assert path == '/get/{id}'
@@ -109,6 +113,7 @@ def test_parametrized_path_with_multiple_prameters():
     request = RequestFactory(url='http://www.example.com/users/john-smith/posts/47')
     path = validate_path_to_api_path(
         path=request.path,
+        context=context,
         **context
     )
     assert path == '/users/{username}/posts/{id}'
@@ -119,8 +124,7 @@ def test_parametrized_path_with_parameter_definition_as_reference():
         paths={
             '/get/{id}': {
                 'parameters': [
-                    # One very plain id of type string.
-                    'id',
+                    {'$ref': '#/parameters/id'}
                 ],
             },
         },
@@ -138,6 +142,7 @@ def test_parametrized_path_with_parameter_definition_as_reference():
     request = RequestFactory(url='http://www.example.com/get/12345')
     path = validate_path_to_api_path(
         path=request.path,
+        context=context,
         **context
     )
     assert path == '/get/{id}'

--- a/tests/validation/request/test_request_body_parameter_validation.py
+++ b/tests/validation/request/test_request_body_parameter_validation.py
@@ -45,7 +45,7 @@ def user_post_schema():
         paths={
             '/post/': {
                 'parameters': [
-                    'user',
+                    {'$ref': '#/parameters/user'},
                 ],
                 'post': {
                     'responses': {200: {'description': "Success"}},

--- a/tests/validation/request/test_request_path_validation.py
+++ b/tests/validation/request/test_request_path_validation.py
@@ -136,7 +136,7 @@ def test_request_validation_with_parameter_as_reference():
             '/get/{id}': {
                 'get': {'responses': {200: {'description': 'Success'}}},
                 'parameters': [
-                    'id',
+                    {'$ref': '#/parameters/id'},
                 ]
             },
         },
@@ -193,7 +193,7 @@ def test_request_validation_with_parameter_as_reference_for_invalid_value():
             '/get/{id}': {
                 'get': {'responses': {200: {'description': 'Success'}}},
                 'parameters': [
-                    'id',
+                    {'$ref': '#/parameters/id'},
                 ]
             },
         },

--- a/tests/validation/request/test_request_query_parameter_validation.py
+++ b/tests/validation/request/test_request_query_parameter_validation.py
@@ -35,7 +35,7 @@ def test_request_query_parameter_validation_with_no_declared_parameters():
         paths={
             '/get/{id}/': {
                 'parameters': [
-                    'id',
+                    {'$ref': '#/parameters/id'},
                 ],
                 'get': {
                     'responses': {200: {'description': "Success"}},

--- a/tests/validation/response/test_response_path_validation.py
+++ b/tests/validation/response/test_response_path_validation.py
@@ -197,7 +197,7 @@ def test_response_validation_with_parameter_as_reference():
             '/get/{id}': {
                 'get': {'responses': {200: {'description': 'Success'}}},
                 'parameters': [
-                    'id',
+                    {'$ref': '#/parameters/id'},
                 ]
             },
         },
@@ -231,7 +231,7 @@ def test_response_validation_with_parameter_as_reference_for_invalid_value():
             '/get/{id}': {
                 'get': {'responses': {200: {'description': 'Success'}}},
                 'parameters': [
-                    'id',
+                    {'$ref': '#/parameters/id'},
                 ]
             },
         },


### PR DESCRIPTION
### What is the problem / feature ?

The handling of the swagger `responseObject` was wrong.  Basically, anything that allowed for either the local object or a ref object was validating the ref object as if it was the local object.

### How did it get fixed / implemented ?

Fixed handling of ref objects.

### How can someone test / see it ?

Try to validate a path with a response that is a reference and see that it doesn't complain.

*Here is a cute animal picture for your troubles...*
![b343526d-70ae-4201-984b-1a9cfacc5eb5](https://cloud.githubusercontent.com/assets/824194/7436238/c619cd00-f008-11e4-98a8-41b975ddc578.png)
