### PR TITLE
Fixes #82 - Add additionalProperties validation

### DIFF
--- a/flex/error_messages.py
+++ b/flex/error_messages.py
@@ -112,6 +112,14 @@ MAX_PROPERTIES_MESSAGES = {
 }
 
 
+ADDITIONAL_PROPERTIES_MESSAGES = {
+    'extra_properties': (
+        "When `additionalProperties` is False, no unspecified properties are "
+        "allowed.  The following unspecified properties were found:\n\t`{0}`"
+    ),
+}
+
+
 ITEMS_MESSAGES = {
     'invalid_type': '`items` must be a reference, a schema, or an array of schemas.',
     'items_required_for_type_array': (
@@ -231,6 +239,7 @@ MESSAGES = {
     'max_items': MAX_ITEMS_MESSAGES,
     'min_properties': MIN_PROPERTIES_MESSAGES,
     'max_properties': MAX_PROPERTIES_MESSAGES,
+    'additional_properties': ADDITIONAL_PROPERTIES_MESSAGES,
     'unique_items': UNIQUE_ITEMS_MESSAGES,
     'enum': ENUM_MESSAGES,
     'pattern': PATTERN_MESSAGES,

--- a/flex/loading/common/schema/__init__.py
+++ b/flex/loading/common/schema/__init__.py
@@ -44,6 +44,11 @@ from flex.loading.common import (
 
 schema_schema = {
     'type': OBJECT,
+    'properties': {
+        'properties': {
+            'type': OBJECT,
+        },
+    }
 }
 
 schema_field_validators = ValidationDict()

--- a/flex/validation/schema.py
+++ b/flex/validation/schema.py
@@ -13,7 +13,6 @@ from flex.error_messages import MESSAGES
 from flex.constants import (
     ARRAY,
     OBJECT,
-    BOOLEAN,
 )
 from flex.decorators import skip_if_not_of_type
 from flex.validation.reference import (

--- a/tests/validation/schema/test_additional_properties_validation.py
+++ b/tests/validation/schema/test_additional_properties_validation.py
@@ -1,0 +1,46 @@
+
+import pytest
+
+from flex.exceptions import ValidationError
+from flex.constants import (
+    STRING,
+    OBJECT,
+)
+
+from tests.utils import generate_validator_from_schema
+
+
+def test_additional_properties_validation_with_no_extra_properties():
+    schema = {
+        'properties': {
+            'name': {
+                'type': STRING,
+            },
+        },
+        'additionalProperties': False,
+    }
+
+    validator = generate_validator_from_schema(schema)
+
+    validator({
+        'name': 'Bob',
+    })
+
+
+def test_additional_properties_validation_with_bad_extra_properties():
+    schema = {
+        'properties': {
+            'name': {
+                'type': STRING,
+            },
+        },
+        'additionalProperties': False,
+    }
+
+    validator = generate_validator_from_schema(schema)
+
+    with pytest.raises(ValidationError):
+        validator({
+            'name': 'Bob',
+            'age': 10,
+        })


### PR DESCRIPTION
# What's broken?

No valdiation was being perform against the [`additionalProperties`](http://json-schema.org/latest/json-schema-validation.html#anchor64) schema keyword.

# How was it fixed.

Added checking against the object keys to see if any additional properties are present whenever `additionalProperties` is Falsy

# How can you see it's fixed?

Issue #82 will be resolved

### Cute animal picture

![animal-friends-4](https://cloud.githubusercontent.com/assets/824194/8413230/4b131c70-1e4c-11e5-8544-1463849c1236.jpg)
