### PR TITLE
Piper/fix max length validation message

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+4.2.0
+-----
+
+- Add validators for the additionalProperties keyword from JSON-schema
+
 4.1.0
 -----
 

--- a/flex/__init__.py
+++ b/flex/__init__.py
@@ -1,3 +1,3 @@
-VERSION = '4.1.0'
+VERSION = '4.2.0'
 
 from flex.core import load  # NOQA

--- a/flex/validation/common.py
+++ b/flex/validation/common.py
@@ -165,7 +165,7 @@ def generate_maximum_validator(maximum, exclusiveMaximum=False, **kwargs):
 @skip_if_not_of_type(STRING)
 def validate_min_length(value, minLength, **kwargs):
     if len(value) < minLength:
-        raise ValidationError(MESSAGES['min_length']['invalid'].format(len(value)))
+        raise ValidationError(MESSAGES['min_length']['invalid'].format(minLength))
 
 
 def generate_min_length_validator(minLength, **kwargs):
@@ -179,7 +179,7 @@ def generate_min_length_validator(minLength, **kwargs):
 @skip_if_not_of_type(STRING)
 def validate_max_length(value, maxLength, **kwargs):
     if len(value) > maxLength:
-        raise ValidationError(MESSAGES['max_length']['invalid'].format(len(value)))
+        raise ValidationError(MESSAGES['max_length']['invalid'].format(maxLength))
 
 
 def generate_max_length_validator(maxLength, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     from distutils.core import setup, find_packages
 
-version = '4.1.0'
+version = '4.2.0'
 
 readme = open(os.path.join(DIR, 'README.md')).read()
 


### PR DESCRIPTION
### What was wrong.

The min/max length error messages were not using the correct number.  In the situation that the `maxLength = 2` and a value of length `5` was passed in, the message would be something like `"value can be no longer than 5"`, when it should be `"value can be no longer than 2"`. 

### how was it fixed

Changed the generation of the message to use `maxLength` rather than `len(value)` for the error message parameter.

#### Cute animal picture

![article-2257173-16c084fa000005dc-478_634x434](https://cloud.githubusercontent.com/assets/824194/8753348/4955b8ae-2c78-11e5-822a-2421df836e46.jpg)
