### PR TITLE
Change CLI tool to swagger-flex

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -200,11 +200,11 @@ can apply to.
 Command line usage
 ------------------
 
-As well as a python API, ``flex`` also provides a commandline validation tool.
+As well as a python API, ``flex`` also provides a commandline validation tool via the ``swagger-flex`` cli.
 
 .. code-block:: bash
-    $ ./flex -s /path/to/swagger.yaml
-    $ ./flex -s http://spec.example.com/swagger.yaml
+    $ ./swagger-flex -s /path/to/swagger.yaml
+    $ ./swagger-flex -s http://spec.example.com/swagger.yaml
 
 
 In the event of a validation error, the commandline program will return 1 and 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     license="BSD",
     zip_safe=False,
     entry_points={
-        'console_scripts': ["flex=flex.cli:main"],
+        'console_scripts': ["swagger-flex=flex.cli:main"],
     },
     keywords='rest swagger',
     packages=find_packages(exclude=["tests", "tests.*"]),


### PR DESCRIPTION
Fixes #93

### What was wrong?

The command line interface for flex used the same executable as http://flex.sourceforge.net/.  This has cause some confusion and problems for people who use both tools.  Since the Apache project has been around for longer, it seems appropriate that this project to change the name of it's command line interface.

### How was it fixed.

The CLI executable is being renamed to `swagger-flex`

#### Sad animal picture

![ca3aa58fe05562dae76764c8c8d0be10](https://cloud.githubusercontent.com/assets/824194/12424283/aff92068-be8c-11e5-9fc9-f51a963ad793.jpg)
