### PR TITLE
don't allow parameters to expand across slashes

### DIFF
--- a/flex/paths.py
+++ b/flex/paths.py
@@ -48,7 +48,7 @@ def construct_parameter_pattern(parameter):
     """
     name = parameter['name']
 
-    return "(?P<{name}>.+)".format(name=name)
+    return "(?P<{name}>[^/]+)".format(name=name)
 
 
 def process_path_part(part, parameters):

--- a/tests/core/test_match_request_path_to_api_path.py
+++ b/tests/core/test_match_request_path_to_api_path.py
@@ -55,7 +55,7 @@ def test_regex_character_escaping(input_, expected):
 
 def test_path_to_pattern_with_single_parameter():
     input_ = '/get/{id}'
-    expected = '^/get/(?P<id>.+)$'
+    expected = '^/get/(?P<id>[^/]+)$'
 
     parameters = parameters_validator([{
         'required': True,
@@ -70,7 +70,7 @@ def test_path_to_pattern_with_single_parameter():
 
 def test_path_to_pattern_with_multiple_parameters():
     input_ = '/get/{first_id}/then/{second_id}/'
-    expected = '^/get/(?P<first_id>.+)/then/(?P<second_id>.+)/$'
+    expected = '^/get/(?P<first_id>[^/]+)/then/(?P<second_id>[^/]+)/$'
 
     parameters = parameters_validator([
         {'required': True, 'name': 'first_id', 'in': 'path', 'type': STRING},

--- a/tests/core/test_path_utils.py
+++ b/tests/core/test_path_utils.py
@@ -1,3 +1,5 @@
+import re
+
 from flex.loading.schema.paths.path_item.operation.parameters import (
     parameters_validator,
 )
@@ -47,4 +49,14 @@ def test_undeclared_api_path_parameters_are_skipped():
     path = '/get/{username}/posts/{id}/'
     parameters = parameters_validator([ID_IN_PATH])
     pattern = path_to_pattern(path, parameters)
-    assert pattern == '^/get/\{username\}/posts/(?P<id>.+)/$'
+    assert pattern == '^/get/\{username\}/posts/(?P<id>[^/]+)/$'
+
+def test_params_do_not_match_across_slashes():
+    path = '/get/{username}/posts/{id}'
+    parameters = parameters_validator([USERNAME_IN_PATH, ID_IN_PATH])
+    pattern = path_to_pattern(path, parameters)
+
+    assert re.match(pattern, '/get/simon/posts/123')
+
+    # {id} should not expand to "/123/unread".
+    assert not re.match(pattern, '/get/simon/posts/123/unread')


### PR DESCRIPTION
This prevents a match of a template `/get/{username}/posts/{id}` to `/get/simon/posts/123/unread`, which I think is the correct behavior.