### PR TITLE
make use of a 'default' response [closes #96]

### DIFF
--- a/flex/validation/response.py
+++ b/flex/validation/response.py
@@ -41,8 +41,13 @@ def validate_status_code_to_response_definition(response, operation_definition):
     """
     status_code = response.status_code
     operation_responses = operation_definition['responses']
+
+    key = status_code
+    if key not in operation_responses:
+        key = 'default'
+
     try:
-        response_definition = operation_responses[status_code]
+        response_definition = operation_responses[key]
     except KeyError:
         raise ValidationError(
             MESSAGES['response']['invalid_status_code'].format(

--- a/tests/validation/response/test_response_status_code_validation.py
+++ b/tests/validation/response/test_response_status_code_validation.py
@@ -43,3 +43,31 @@ def test_response_parameter_validation():
         err.value.messages[0]['status_code'][0],
         MESSAGES['response']['invalid_status_code'],
     )
+
+def test_response_paramater_uses_default():
+    """
+    Test that a `default` key is used if one exists and no matching response is found.
+
+    See http://swagger.io/specification/#responsesObject.
+    """
+
+    schema = SchemaFactory(
+        paths={
+            '/get': {
+                'get': {
+                    'responses': {
+                        200: {'description': 'Success'},
+                        'default': {'description': 'Unexpected error.'}
+                    },
+                },
+            },
+        },
+    )
+
+    response = ResponseFactory(url='http://www.example.com/get', status_code=301)
+
+    validate_response(
+        response=response,
+        request_method='get',
+        schema=schema,
+    )


### PR DESCRIPTION
See #96.¹

¹ see also [this cute picture of a hedgehog](https://s-media-cache-ak0.pinimg.com/564x/47/31/0e/47310ecbfc266abbea3db0cd626fd0dc.jpg).