### PR TITLE
add tornado httpserver.HTTPRequest support

### DIFF
--- a/flex/http.py
+++ b/flex/http.py
@@ -11,6 +11,7 @@ from flex.constants import EMPTY
 _tornado_available = True
 try:
     import tornado.httpclient
+    import tornado.httpserver
 except ImportError:
     _tornado_available = False
 
@@ -130,11 +131,16 @@ def _normalize_tornado_request(request):
     if not _tornado_available:
         raise TypeError("Tornado is not installed")
 
-    if not isinstance(request, tornado.httpclient.HTTPRequest):
+    if isinstance(request, tornado.httpclient.HTTPRequest):
+        url_attr = 'url'
+    elif isinstance(request, tornado.httpserver.HTTPRequest):
+        # This is the only difference in their api that we care about.
+        url_attr = 'uri'
+    else:
         raise TypeError("Cannot normalize this request object")
 
     return Request(
-        url=request.url,
+        url=getattr(request, url_attr),
         body=request.body,
         method=request.method.lower(),
         content_type=request.headers.get('Content-Type'),

--- a/flex/http.py
+++ b/flex/http.py
@@ -132,15 +132,15 @@ def _normalize_tornado_request(request):
         raise TypeError("Tornado is not installed")
 
     if isinstance(request, tornado.httpclient.HTTPRequest):
-        url_attr = 'url'
+        url = request.url
     elif isinstance(request, tornado.httpserver.HTTPRequest):
         # This is the only difference in their api that we care about.
-        url_attr = 'uri'
+        url = request.uri
     else:
         raise TypeError("Cannot normalize this request object")
 
     return Request(
-        url=getattr(request, url_attr),
+        url=url,
         body=request.body,
         method=request.method.lower(),
         content_type=request.headers.get('Content-Type'),

--- a/tests/http/test_request_normalization.py
+++ b/tests/http/test_request_normalization.py
@@ -77,11 +77,11 @@ def test_python3_urllib_request_normalization(httpbin):
 # Test tornado request object
 #
 @pytest.mark.skipif(not _tornado_available, reason="tornado not installed")
-def test_tornado_request_normalization(httpbin):
+def test_tornado_client_request_normalization(httpbin):
     import tornado.httpclient
 
     raw_request = tornado.httpclient.HTTPRequest(
-        httpbin.url + '/get',
+        httpbin.url + '/get?key=val',
         headers={'Content-Type': 'application/json'}
     )
 
@@ -89,5 +89,22 @@ def test_tornado_request_normalization(httpbin):
 
     assert request.path == '/get'
     assert request.content_type == 'application/json'
-    assert request.url == httpbin.url + '/get'
+    assert request.url == httpbin.url + '/get?key=val'
+    assert request.method == 'get'
+
+@pytest.mark.skipif(not _tornado_available, reason="tornado not installed")
+def test_tornado_server_request_normalization(httpbin):
+    import tornado.httpserver
+
+    raw_request = tornado.httpserver.HTTPRequest(
+        'GET',
+        httpbin.url + '/get?key=val',
+        headers={'Content-Type': 'application/json'}
+    )
+
+    request = normalize_request(raw_request)
+
+    assert request.path == '/get'
+    assert request.content_type == 'application/json'
+    assert request.url == httpbin.url + '/get?key=val'
     assert request.method == 'get'


### PR DESCRIPTION
Apparently tornado uses a separate HTTPRequest in the server; who knew.

This adds support for it as well.