### PR TITLE
pass through kwargs to validate subcalls

### DIFF
--- a/flex/core.py
+++ b/flex/core.py
@@ -105,10 +105,10 @@ def validate(raw_schema, target=None, **kwargs):
     spec, validate that the schema complies to spec.  If `target` is provided,
     that target will be validated against the provided schema.
     """
-    schema = schema_validator(raw_schema)
+    schema = schema_validator(raw_schema, **kwargs)
 
     if target is not None:
-        validate_object(target, schema=schema)
+        validate_object(target, schema=schema, **kwargs)
 
 
 def validate_api_call(schema, raw_request, raw_response):


### PR DESCRIPTION
I think this was the intended behavior, but I'm not entirely sure. The tests did pass, so if it's not it at least seems backwards compatible.

For context, our use case is schema generation from examples. To match and replace existing definitions, we're making a call like `validate(isolated_definition, example_body, context=schema)` for each existing definition, and generating a reference when validating succeeds. The context is needed for the case where isolated_definition references another definition.

And here's a [cute octopus](http://blogs.discovermagazine.com/d-brief/files/2015/06/octopus.jpg)!