### PR TITLE
generate path regexes with \d for integers [#58]

### DIFF
--- a/flex/paths.py
+++ b/flex/paths.py
@@ -47,8 +47,14 @@ def construct_parameter_pattern(parameter):
     part of the path.
     """
     name = parameter['name']
+    type = parameter['type']
 
-    return "(?P<{name}>[^/]+)".format(name=name)
+    repeated = '[^/]'
+
+    if type == 'integer':
+        repeated = '\d'
+
+    return "(?P<{name}>{repeated}+)".format(name=name, repeated=repeated)
 
 
 def process_path_part(part, parameters):

--- a/tests/core/test_path_utils.py
+++ b/tests/core/test_path_utils.py
@@ -49,7 +49,7 @@ def test_undeclared_api_path_parameters_are_skipped():
     path = '/get/{username}/posts/{id}/'
     parameters = parameters_validator([ID_IN_PATH])
     pattern = path_to_pattern(path, parameters)
-    assert pattern == '^/get/\{username\}/posts/(?P<id>[^/]+)/$'
+    assert pattern == r'^/get/\{username\}/posts/(?P<id>\d+)/$'
 
 def test_params_do_not_match_across_slashes():
     path = '/get/{username}/posts/{id}'

--- a/tests/validation/request/test_request_path_validation.py
+++ b/tests/validation/request/test_request_path_validation.py
@@ -120,9 +120,9 @@ def test_request_validation_with_parametrized_path_with_invalid_value():
         )
 
     assert_message_in_errors(
-        MESSAGES['type']['invalid'],
+        MESSAGES['path']['no_matching_paths_found'],
         err.value.detail,
-        'path.id.type',
+        'path',
     )
 
 
@@ -217,7 +217,7 @@ def test_request_validation_with_parameter_as_reference_for_invalid_value():
         )
 
     assert_message_in_errors(
-        MESSAGES['type']['invalid'],
+        MESSAGES['path']['no_matching_paths_found'],
         err.value.detail,
-        'path.id.type',
+        'path',
     )

--- a/tests/validation/response/test_response_path_validation.py
+++ b/tests/validation/response/test_response_path_validation.py
@@ -181,9 +181,9 @@ def test_response_validation_with_parametrized_path_and_invalid_value():
         )
 
     assert_message_in_errors(
-        MESSAGES['type']['invalid'],
+        MESSAGES['path']['no_matching_paths_found'],
         err.value.detail,
-        'path.id.type',
+        'path',
     )
 
 
@@ -256,7 +256,7 @@ def test_response_validation_with_parameter_as_reference_for_invalid_value():
         )
 
     assert_message_in_errors(
-        MESSAGES['type']['invalid'],
+        MESSAGES['path']['no_matching_paths_found'],
         err.value.detail,
-        'path.id.type',
+        'path',
     )


### PR DESCRIPTION
This prevents matching a path like `/foo/bar` to a definition like `/foo/{id}` when id is an integer param.

Note that this is a breaking change if users were relying on the "got value of type..." message instead of "no paths found".

[also check out this kangaroo](http://justcuteanimals.com/wp-content/uploads/2014/11/Little-kangaroo-pictures-cute-animal-pics.jpg)