### PR TITLE
Tyepcast query param parameters

### DIFF
--- a/flex/exceptions.py
+++ b/flex/exceptions.py
@@ -95,3 +95,10 @@ class ValidationError(ValueError):
 
 class MultiplePathsFound(ValueError):
     pass
+
+
+class NoParameterFound(ValueError):
+    pass
+
+class MultipleParametersFound(ValueError):
+    pass

--- a/flex/exceptions.py
+++ b/flex/exceptions.py
@@ -100,5 +100,6 @@ class MultiplePathsFound(ValueError):
 class NoParameterFound(ValueError):
     pass
 
+
 class MultipleParametersFound(ValueError):
     pass

--- a/flex/parameters.py
+++ b/flex/parameters.py
@@ -1,4 +1,8 @@
 from flex.decorators import rewrite_reserved_words
+from flex.exceptions import (
+    MultipleParametersFound,
+    NoParameterFound,
+)
 from flex.utils import dereference_reference
 
 
@@ -26,8 +30,8 @@ def find_parameter(parameters, **kwargs):
     if len(matching_parameters) == 1:
         return matching_parameters[0]
     elif len(matching_parameters) > 1:
-        raise ValueError("More than 1 parameter matched")
-    raise ValueError("No parameters matched")
+        raise NoParameterFound()
+    raise MultipleParametersFound()
 
 
 def merge_parameter_lists(*parameter_definitions):

--- a/flex/validation/parameter.py
+++ b/flex/validation/parameter.py
@@ -3,6 +3,7 @@ from flex.utils import is_non_string_iterable
 from flex.exceptions import ValidationError
 from flex.error_messages import MESSAGES
 from flex.context_managers import ErrorCollection
+from flex.functional import chain_reduce_partial
 from flex.validation.reference import (
     LazyReferenceValidator,
 )
@@ -51,6 +52,8 @@ def type_cast_parameters(parameter_values, parameter_definitions, context):
             parameter_definition = find_parameter(parameter_definitions, name=key)
         except KeyError:
             continue
+        except ValueError:
+            continue
         value = parameter_values[key]
         value_processor = generate_value_processor(context=context, **parameter_definition)
         typed_parameters[key] = value_processor(value)
@@ -85,6 +88,7 @@ def validate_query_parameters(raw_query_data, query_parameters, context):
             query_data[key] = value[0]
         else:
             query_data[key] = value
+    query_data = type_cast_parameters(query_data, query_parameters, context)
     validate_parameters(query_data, query_parameters, context)
 
 

--- a/flex/validation/parameter.py
+++ b/flex/validation/parameter.py
@@ -3,7 +3,6 @@ from flex.utils import is_non_string_iterable
 from flex.exceptions import ValidationError
 from flex.error_messages import MESSAGES
 from flex.context_managers import ErrorCollection
-from flex.functional import chain_reduce_partial
 from flex.validation.reference import (
     LazyReferenceValidator,
 )

--- a/flex/validation/parameter.py
+++ b/flex/validation/parameter.py
@@ -1,6 +1,10 @@
 from flex.datastructures import ValidationDict
 from flex.utils import is_non_string_iterable
-from flex.exceptions import ValidationError
+from flex.exceptions import (
+    ValidationError,
+    MultipleParametersFound,
+    NoParameterFound,
+)
 from flex.error_messages import MESSAGES
 from flex.context_managers import ErrorCollection
 from flex.validation.reference import (
@@ -49,9 +53,7 @@ def type_cast_parameters(parameter_values, parameter_definitions, context):
     for key in parameter_values.keys():
         try:
             parameter_definition = find_parameter(parameter_definitions, name=key)
-        except KeyError:
-            continue
-        except ValueError:
+        except (KeyError, MultipleParametersFound, NoParameterFound):
             continue
         value = parameter_values[key]
         value_processor = generate_value_processor(context=context, **parameter_definition)

--- a/tests/validation/request/test_request_header_validation.py
+++ b/tests/validation/request/test_request_header_validation.py
@@ -27,7 +27,7 @@ def test_request_header_validation():
         paths={
             '/get/': {
                 'get': {
-                    'responses': {200: {'description': "Success"}},
+                    'responses': {'200': {'description': "Success"}},
                     'parameters': [
                         {
                             'name': 'Authorization',
@@ -57,6 +57,16 @@ def test_request_header_validation():
         'method.parameters.headers.Authorization.type',
     )
 
+    # integers within strings since headers are strings + undeclared parameters:
+    request = RequestFactory(
+        url='http://www.example.com/get/?foo=1',
+        headers={'Authorization': '123'},
+    )
+
+    validate_request(
+        request=request,
+        schema=schema,
+    )
 
 @pytest.mark.parametrize(
     'format_,value',

--- a/tests/validation/request/test_request_parameter_validation.py
+++ b/tests/validation/request/test_request_parameter_validation.py
@@ -6,6 +6,8 @@ from flex.validation.request import (
 )
 from flex.error_messages import MESSAGES
 from flex.constants import (
+    ARRAY,
+    CSV,
     PATH,
     QUERY,
     STRING,
@@ -97,6 +99,45 @@ def test_request_parameter_validation_with_base_path():
     )
 
     request = RequestFactory(url='http://www.example.com/api/v1/get/32/')
+
+    validate_request(
+        request=request,
+        schema=schema,
+    )
+
+
+def test_request_parameter_validation_typecasting():
+    """
+    Test that request validation does parameter validation for all parameters that require
+    typecasting or array split since query params are generally treated as strings.
+    """
+    schema = SchemaFactory(
+        paths={
+            '/get/': {
+                'parameters': [
+                    {
+                        'name': 'id',
+                        'in': QUERY,
+                        'type': INTEGER,
+                    },
+                    {
+                        'name': 'usernames',
+                        'in': QUERY,
+                        'type': ARRAY,
+                        'items': {
+                            'type': STRING
+                        },
+                        'collectionFormat': CSV
+                    },
+                ],
+                'get': {
+                    'responses': {200: {'description': "Success"}},
+                },
+            },
+        },
+    )
+
+    request = RequestFactory(url='http://www.example.com/get/?id=32&usernames=abc,def')
 
     validate_request(
         request=request,


### PR DESCRIPTION
Typecast values passed in as query params since they are generally treated as strings.

Also, split arrays based on collection format

Fixes pipermerriam/flex#114