### PR TITLE
Adding NULL support

### DIFF
--- a/flex/validation/common.py
+++ b/flex/validation/common.py
@@ -32,6 +32,7 @@ from flex.paths import (
     match_path_to_api_path,
 )
 from flex.constants import (
+    NULL,
     NUMBER,
     STRING,
     ARRAY,
@@ -67,6 +68,10 @@ def generate_type_validator(type_, **kwargs):
         types = type_
     else:
         types = (type_,)
+    # support x-nullable since Swagger 2.0 doesn't support null type
+    # (see https://github.com/OAI/OpenAPI-Specification/issues/229)
+    if kwargs.get('x-nullable', False) and NULL not in types:
+        types = types + (NULL,)
     return functools.partial(validate_type, types=types)
 
 

--- a/tests/validation/request/test_request_body_parameter_validation.py
+++ b/tests/validation/request/test_request_body_parameter_validation.py
@@ -38,6 +38,7 @@ def user_post_schema():
                     'properties': {
                         'username': {'type': STRING},
                         'email': {'type': STRING, 'format': 'email'},
+                        'age': {'type': INTEGER, 'x-nullable': True},
                     },
                 },
             },
@@ -64,6 +65,23 @@ def test_request_body_parameter_validation_with_valid_value(user_post_schema):
         url='http://www.example.com/post/',
         content_type='application/json',
         body=json.dumps({'username': 'Test User', 'email': 'test@example.com'}),
+        method=POST,
+    )
+
+    validate_request(
+        request=request,
+        schema=user_post_schema,
+    )
+
+
+def test_request_body_parameter_validation_with_nullable_field(user_post_schema):
+    """
+    Test validating the request body with a valid post.
+    """
+    request = RequestFactory(
+        url='http://www.example.com/post/',
+        content_type='application/json',
+        body=json.dumps({'username': 'Test User', 'email': 'test@example.com', 'age': None}),
         method=POST,
     )
 

--- a/tests/validation/response/test_schema_validation.py
+++ b/tests/validation/response/test_schema_validation.py
@@ -57,6 +57,42 @@ def test_basic_response_body_schema_validation_with_invalid_value():
     )
 
 
+def test_basic_response_body_schema_validation_with_nullable_value():
+    """
+    Ensure objects marked with x-nullable: true attribute are treated as nullable.
+    """
+    schema = SchemaFactory(
+        paths={
+            '/get': {
+                'get': {
+                    'responses': {
+                        200: {
+                            'description': 'Success',
+                            'schema': {
+                                'type': INTEGER,
+                                'x-nullable': True
+                            },
+                        }
+                    },
+                },
+            },
+        },
+    )
+
+    response = ResponseFactory(
+        url='http://www.example.com/get',
+        status_code=200,
+        content_type='application/json',
+        content=json.dumps(None),
+    )
+
+    validate_response(
+        response=response,
+        request_method='get',
+        schema=schema,
+    )
+
+
 def test_basic_response_body_schema_validation_with_type_mismatch():
     """
     Ensure that when the expected response type is an object, and some other

--- a/tests/validation/response/test_schema_validation.py
+++ b/tests/validation/response/test_schema_validation.py
@@ -66,7 +66,7 @@ def test_basic_response_body_schema_validation_with_nullable_value():
             '/get': {
                 'get': {
                     'responses': {
-                        200: {
+                        '200': {
                             'description': 'Success',
                             'schema': {
                                 'type': INTEGER,


### PR DESCRIPTION
Swagger 2.0 does NOT support null in type array
(https://github.com/OAI/OpenAPI-Specification/issues/229). For now, using the
`x-nullable` extension is the best way.

Fixes pipermerriam/flex#91