### PR TITLE
Fix "methodcaller does not take keyword arguments" error with Python 2.7.12

### DIFF
--- a/flex/functional.py
+++ b/flex/functional.py
@@ -40,5 +40,14 @@ def apply_functions_to_key(key, *funcs):
     validator to some specified key in a mapping.
     """
     return chain_reduce_partial(
-        operator.methodcaller('get', key, EMPTY), *funcs
+        methodcaller('get', key, EMPTY), *funcs
     )
+
+
+def attrgetter(attr):
+    return lambda obj, **kwargs: getattr(obj, attr)
+
+
+def methodcaller(name, *args):
+    func = operator.methodcaller(name, *args)
+    return lambda obj, **kwargs: func(obj)

--- a/flex/validation/operation.py
+++ b/flex/validation/operation.py
@@ -1,9 +1,9 @@
 import functools
-import operator
 
 from flex.datastructures import ValidationDict
 from flex.exceptions import ValidationError
 from flex.utils import chain_reduce_partial
+from flex.functional import attrgetter
 from flex.context_managers import ErrorCollection
 from flex.http import (
     Request,
@@ -135,7 +135,7 @@ def generate_parameters_validator(api_path, path_definition, parameters,
     validators.add_validator(
         'path',
         chain_reduce_partial(
-            operator.attrgetter('path'),
+            attrgetter('path'),
             generate_path_parameters_validator(api_path, in_path_parameters, context),
         ),
     )
@@ -145,7 +145,7 @@ def generate_parameters_validator(api_path, path_definition, parameters,
     validators.add_validator(
         'query',
         chain_reduce_partial(
-            operator.attrgetter('query_data'),
+            attrgetter('query_data'),
             functools.partial(
                 validate_query_parameters,
                 query_parameters=in_query_parameters,
@@ -159,7 +159,7 @@ def generate_parameters_validator(api_path, path_definition, parameters,
     validators.add_validator(
         'headers',
         chain_reduce_partial(
-            operator.attrgetter('headers'),
+            attrgetter('headers'),
             generate_header_validator(in_header_parameters, context),
         ),
     )
@@ -169,7 +169,7 @@ def generate_parameters_validator(api_path, path_definition, parameters,
     # validators.add_validator(
     #     'form_data',
     #     chain_reduce_partial(
-    #         operator.attrgetter('data'),
+    #         attrgetter('data'),
     #         generate_form_data_validator(in_form_data_parameters, context),
     #     )
     # )
@@ -179,7 +179,7 @@ def generate_parameters_validator(api_path, path_definition, parameters,
     validators.add_validator(
         'request_body',
         chain_reduce_partial(
-            operator.attrgetter('data'),
+            attrgetter('data'),
             generate_request_body_validator(in_request_body_parameters, context),
         )
     )

--- a/flex/validation/response.py
+++ b/flex/validation/response.py
@@ -1,9 +1,9 @@
 import functools
-import operator
 
 from flex.datastructures import ValidationDict
 from flex.exceptions import ValidationError
 from flex.utils import chain_reduce_partial
+from flex.functional import attrgetter, methodcaller
 from flex.context_managers import ErrorCollection
 from flex.validation.common import (
     validate_object,
@@ -59,7 +59,7 @@ def validate_status_code_to_response_definition(response, operation_definition):
 
 def generate_response_body_validator(schema, context, **kwargs):
     return chain_reduce_partial(
-        operator.attrgetter('data'),
+        attrgetter('data'),
         functools.partial(
             validate_object,
             schema=schema,
@@ -87,12 +87,12 @@ def generate_response_header_validator(headers, context, **kwargs):
         # `response.headers.get(header_name, EMPTY)` and then feed that into
         # the type casting function and then into the validation function.
         validators.add_validator(key, chain_reduce_partial(
-            operator.methodcaller('get', key, EMPTY),
+            methodcaller('get', key, EMPTY),
             header_processor,
             header_validator,
         ))
     return chain_reduce_partial(
-        operator.attrgetter('headers'),
+        attrgetter('headers'),
         functools.partial(validate_object, field_validators=validators),
     )
 
@@ -136,7 +136,7 @@ def generate_path_validator(api_path, path_definition, parameters,
     # PATH
     in_path_parameters = filter_parameters(all_parameters, in_=PATH)
     return chain_reduce_partial(
-        operator.attrgetter('path'),
+        attrgetter('path'),
         generate_path_parameters_validator(api_path, in_path_parameters, context),
     )
 


### PR DESCRIPTION
The problem reported in #120 is reproducible under Python 2.7.12 which makes the bug slightly more serious. During validation `context` keyword argument is passed to `operator.attrgetter` and `operator.methodcaller` functions. It's not allowed by their signatures, but so far it was ignored due to a bug in Python (https://bugs.python.org/issue26822).

I took the laziest possible approach to fixing it - simply by bringing back former behavior to `attrgetter` and `methodcaller`.