### PR TITLE
Expand coverage to py35 and actually test the falcon stuff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,11 @@ env:
     - PIP_DOWNLOAD_CACHE=$HOME/.pip_cache
   matrix:
     - TOX_ENV=py27
-    - TOX_ENV=py27-with-tornado
+    - TOX_ENV=py27-with-tornado-falcon
     - TOX_ENV=py34
-    - TOX_ENV=py34-with-tornado
+    - TOX_ENV=py34-with-tornado-falcon
+    - TOX_ENV=py35
+    - TOX_ENV=py35-with-tornado-falcon
     - TOX_ENV=flake8
 cache:
   directories:

--- a/flex/__init__.py
+++ b/flex/__init__.py
@@ -1,3 +1,3 @@
-VERSION = '5.7.0'
+VERSION = '5.8.0'
 
 from flex.core import load  # NOQA

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pytest==2.6.3
+pytest>=3.0.3
 pytest-pythonpath==0.3
 tox==1.8.0
 pytest-httpbin==0.0.3

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,8 @@ envlist=
     py27-with-tornado-falcon,
     py34,
     py34-with-tornado-falcon,
+    py35,
+    py35-with-tornado-falcon,
     flake8
 
 [flake8]
@@ -30,6 +32,16 @@ basepython=python3.4
 
 [testenv:py34-with-tornado-falcon]
 basepython=python3.4
+deps =
+    -r{toxinidir}/requirements-dev.txt
+    tornado
+    falcon
+
+[testenv:py35]
+basepython=python3.5
+
+[testenv:py35-with-tornado-falcon]
+basepython=python3.5
 deps =
     -r{toxinidir}/requirements-dev.txt
     tornado


### PR DESCRIPTION
### What was wrong?

* No testing against python 3.5
* The falcon tests weren't actually being run due to travis ci file not being updated.

### How was it fixed

Changed the testing configurations

#### Cute animal picture

![f271c32597a3721d256d728fb3b131af](https://cloud.githubusercontent.com/assets/824194/19003271/4cdadf04-870d-11e6-9df5-b01e7a76774b.jpg)
