### PR TITLE
Convert body to str when type is bytes

### DIFF
--- a/flex/http.py
+++ b/flex/http.py
@@ -68,7 +68,10 @@ class Request(URLMixin):
         elif self.body is EMPTY:
             return EMPTY
         elif self.content_type.startswith('application/json'):
-            return json.loads(self.body)
+            if type(self.body) == bytes:
+                return json.loads(str(self.body, 'utf-8'))
+            else:
+                return json.loads(self.body)
         elif self.content_type == 'application/x-www-form-urlencoded':
             return dict(urlparse.parse_qsl(self.body))
         else:

--- a/flex/http.py
+++ b/flex/http.py
@@ -69,7 +69,7 @@ class Request(URLMixin):
             return EMPTY
         elif self.content_type.startswith('application/json'):
             if type(self.body) == bytes:
-                return json.loads(str(self.body, 'utf-8'))
+                return json.loads(self.body.decode('utf-8'))
             else:
                 return json.loads(self.body)
         elif self.content_type == 'application/x-www-form-urlencoded':

--- a/tests/http/test_request_data_property.py
+++ b/tests/http/test_request_data_property.py
@@ -30,6 +30,15 @@ def test_json_content_type_with_json_body():
     assert request.data == {'key': 'value', 'key2': 'value2', 'key[1]': 'subvalue1', 'key[2]': 'subvalue2'}
 
 
+def test_json_content_type_with_json_bytes_body():
+    body = bytes(json.dumps({'key': 'value', 'key2': 'value2', 'key[1]': 'subvalue1', 'key[2]': 'subvalue2'}), 'utf-8')
+    request = RequestFactory(
+        body=body,
+        content_type='application/json',
+    )
+    assert request.data == {'key': 'value', 'key2': 'value2', 'key[1]': 'subvalue1', 'key[2]': 'subvalue2'}
+
+
 def test_form_content_type_with_body():
     request = RequestFactory(
         body="key=value&key2=value2&arr[1]=subvalue1&arr[2]=subvalue2",

--- a/tests/http/test_request_data_property.py
+++ b/tests/http/test_request_data_property.py
@@ -31,7 +31,8 @@ def test_json_content_type_with_json_body():
 
 
 def test_json_content_type_with_json_bytes_body():
-    body = bytes(json.dumps({'key': 'value', 'key2': 'value2', 'key[1]': 'subvalue1', 'key[2]': 'subvalue2'}), 'utf-8')
+    body = json.dumps({'key': 'value', 'key2': 'value2', 'key[1]': 'subvalue1', 'key[2]': 'subvalue2'}).encode('utf-8')
+    assert type(body) == bytes
     request = RequestFactory(
         body=body,
         content_type='application/json',


### PR DESCRIPTION
Convert body to str when type is bytes to fix a problem in request validations in python 3.