### PR TITLE
Add webob normalization

### DIFF
--- a/flex/http.py
+++ b/flex/http.py
@@ -322,10 +322,14 @@ def _normalize_webob_response(response, request=None):
     if not isinstance(response, webob.Response):
         raise TypeError("Cannot normalize this response object")
 
+    url = None
+
     if request:
         url = request.url
+    elif response.request:
+        url = response.request.url
     else:
-        url = None
+        raise TypeError("Normalized webob object needs a path")
 
     return Response(
         request=request,

--- a/flex/http.py
+++ b/flex/http.py
@@ -31,6 +31,7 @@ except ImportError:
 else:
     _webob_available = True
 
+
 class URLMixin(object):
     @property
     def url_components(self):
@@ -199,6 +200,7 @@ def _normalize_webob_request(request):
         request=request,
     )
 
+
 REQUEST_NORMALIZERS = (
     _normalize_python2_urllib_request,
     _normalize_python3_urllib_request,
@@ -207,6 +209,7 @@ REQUEST_NORMALIZERS = (
     _normalize_tornado_request,
     _normalize_falcon_request,
 )
+
 
 def normalize_request(request):
     """
@@ -314,6 +317,7 @@ def _normalize_tornado_response(response, request=None):
         content_type=response.headers.get('Content-Type'),
         response=response,
     )
+
 
 def _normalize_webob_response(response, request=None):
     if not _webob_available:

--- a/flex/http.py
+++ b/flex/http.py
@@ -188,7 +188,7 @@ def _normalize_webob_request(request):
     if not _webob_available:
         raise TypeError("webob is not installed")
 
-    if not isinstance(request, webob.Request):
+    if not isinstance(request, webob.BaseRequest):
             raise TypeError("Cannot normalize this request object")
 
     return Request(

--- a/tests/http/test_request_normalization.py
+++ b/tests/http/test_request_normalization.py
@@ -135,22 +135,6 @@ def test_falcon_request_normalization(httpbin):
     assert request.method == 'put'
     assert request.body == '{"key2": "val2"}'
 
-@pytest.mark.skipif(not _tornado_available, reason="tornado not installed")
-def test_tornado_server_request_normalization(httpbin):
-    import tornado.httpserver
-
-    raw_request = tornado.httpserver.HTTPRequest(
-        'GET',
-        httpbin.url + '/get?key=val',
-        headers={'Content-Type': 'application/json'}
-    )
-
-    request = normalize_request(raw_request)
-
-    assert request.path == '/get'
-    assert request.content_type == 'application/json'
-    assert request.url == httpbin.url + '/get?key=val'
-    assert request.method == 'get'
 
 @pytest.mark.skipif(not _webob_available, reason="webob not installed")
 def test_webob_client_request_normalization(httpbin):

--- a/tests/http/test_request_normalization.py
+++ b/tests/http/test_request_normalization.py
@@ -6,7 +6,7 @@ import six
 import requests
 
 from flex.http import (
-    normalize_request, _tornado_available, _falcon_available
+    normalize_request, _tornado_available, _falcon_available, _webob_available
 )
 
 
@@ -134,3 +134,36 @@ def test_falcon_request_normalization(httpbin):
     assert request.url == httpbin.url + '/put?key=val'
     assert request.method == 'put'
     assert request.body == '{"key2": "val2"}'
+
+@pytest.mark.skipif(not _tornado_available, reason="tornado not installed")
+def test_tornado_server_request_normalization(httpbin):
+    import tornado.httpserver
+
+    raw_request = tornado.httpserver.HTTPRequest(
+        'GET',
+        httpbin.url + '/get?key=val',
+        headers={'Content-Type': 'application/json'}
+    )
+
+    request = normalize_request(raw_request)
+
+    assert request.path == '/get'
+    assert request.content_type == 'application/json'
+    assert request.url == httpbin.url + '/get?key=val'
+    assert request.method == 'get'
+
+@pytest.mark.skipif(not _webob_available, reason="webob not installed")
+def test_webob_client_request_normalization(httpbin):
+    import webob
+
+    raw_request = webob.Request.blank(httpbin.url + '/get')
+    raw_request.query_string = 'key=val'
+    raw_request.method = 'GET'
+    raw_request.content_type = 'application/json'
+
+    request = normalize_request(raw_request)
+
+    assert request.path == '/get'
+    assert request.content_type == 'application/json'
+    assert request.url == httpbin.url + '/get?key=val'
+    assert request.method == 'get'

--- a/tests/http/test_response_normalization.py
+++ b/tests/http/test_response_normalization.py
@@ -7,7 +7,7 @@ import urllib
 import requests
 
 from flex.http import (
-    normalize_response, _tornado_available
+    normalize_response, _tornado_available, _webob_available
 )
 
 
@@ -76,4 +76,27 @@ def test_tornado_response_normalization(httpbin):
     assert response.path == '/get'
     assert response.content_type == 'application/json'
     assert response.url == httpbin.url + '/get'
+    assert response.status_code == '200'
+
+
+#
+# Test webob response object
+#
+@pytest.mark.skipif(not _webob_available, reason="webob not installed")
+def test_webob_response_normalization(httpbin):
+    import webob
+
+    raw_request = webob.Request.blank(httpbin.url + '/get')
+    raw_request.query_string = 'key=val'
+    raw_request.method = 'GET'
+    raw_request.content_type = 'application/json'
+
+    raw_response = webob.Response()
+    raw_response.content_type = 'application/json'
+
+    response = normalize_response(raw_response, raw_request)
+
+    assert response.path == '/get'
+    assert response.content_type == 'application/json'
+    assert response.url == httpbin.url + '/get?key=val'
     assert response.status_code == '200'

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,12 @@
 envlist=
     py27,
     py27-with-tornado-falcon,
+    py2-with-webob,
     py34,
     py34-with-tornado-falcon,
     py35,
     py35-with-tornado-falcon,
+    py3-with-webob,
     flake8
 
 [flake8]
@@ -27,6 +29,12 @@ deps =
     tornado
     falcon
 
+[testenv:py2-with-webob]
+basepython=python2.7
+deps =
+    -r{toxinidir}/requirements-dev.txt
+    webob
+
 [testenv:py34]
 basepython=python3.4
 
@@ -46,6 +54,12 @@ deps =
     -r{toxinidir}/requirements-dev.txt
     tornado
     falcon
+
+[testenv:py3-with-webob]
+basepython=python3.5
+deps =
+    -r{toxinidir}/requirements-dev.txt
+    webob
 
 [testenv:flake8]
 basepython=python


### PR DESCRIPTION
Add support for normalizing WebOb requests and responses. This lets us use the flex validator with the [WebTest functional testing framework](http://docs.pylonsproject.org/projects/webtest/en/latest/)