### PR TITLE
Add a method for just validating the API response

### DIFF
--- a/flex/core.py
+++ b/flex/core.py
@@ -117,6 +117,22 @@ def validate_api_request(schema, raw_request):
         validate_request(request=request, schema=schema)
 
 
+def validate_api_response(schema, raw_response, request_method='get'):
+    """
+    Validate the response of an api call against a swagger schema.
+    """
+    response = None
+    if raw_response is not None:
+        response = normalize_response(raw_response)
+
+    if response is not None:
+        validate_response(
+            response=response,
+            request_method=request_method,
+            schema=schema
+        )
+
+
 def validate_api_call(schema, raw_request, raw_response):
     """
     Validate the request/response cycle of an api call against a swagger
@@ -124,9 +140,6 @@ def validate_api_call(schema, raw_request, raw_response):
     are supported.
     """
     request = normalize_request(raw_request)
-    response = None
-    if raw_response is not None:
-        response = normalize_response(raw_response)
 
     with ErrorCollection() as errors:
         try:
@@ -139,11 +152,10 @@ def validate_api_call(schema, raw_request, raw_response):
             return
 
         try:
-            if response is not None:
-                validate_response(
-                    response=response,
-                    request_method=request.method,
-                    schema=schema,
-                )
+            validate_api_response(
+                raw_response=raw_response,
+                request_method=request.method,
+                schema=schema
+            )
         except ValidationError as err:
             errors['response'].add_error(err.messages or getattr(err, 'detail'))

--- a/tests/validation/api_call/test_api_call_validation.py
+++ b/tests/validation/api_call/test_api_call_validation.py
@@ -5,7 +5,7 @@ import responses
 import json
 
 from flex.exceptions import ValidationError
-from flex.core import load, validate_api_call, validate_api_request
+from flex.core import load, validate_api_call, validate_api_request, validate_api_response
 from flex.error_messages import MESSAGES
 
 import pytest
@@ -21,6 +21,12 @@ def test_validate_api_request(httpbin):
     schema = load(os.path.join(BASE_DIR, 'schemas', 'httpbin.yaml'))
     response = requests.get(urlparse.urljoin(httpbin.url, '/get'))
     validate_api_request(schema, raw_request=response.request)
+
+
+def test_validate_api_response(httpbin):
+    schema = load(os.path.join(BASE_DIR, 'schemas', 'httpbin.yaml'))
+    response = requests.get(urlparse.urljoin(httpbin.url, '/get'))
+    validate_api_response(schema, raw_response=response)
 
 
 def test_validate_api_call(httpbin):


### PR DESCRIPTION
This is useful for situations where you might send a deliberately malformed request that doesn't match your Swagger specification but you want to test the error response does match.

Fixes https://github.com/pipermerriam/flex/issues/149