### PR TITLE
Add django request/response normalization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,16 @@ env:
     - PIP_DOWNLOAD_CACHE=$HOME/.pip_cache
   matrix:
     - TOX_ENV=py27
+    - TOX_ENV=py27-with-django19
+    - TOX_ENV=py27-with-django110
     - TOX_ENV=py27-with-tornado-falcon
     - TOX_ENV=py34
+    - TOX_ENV=py34-with-django19
+    - TOX_ENV=py34-with-django110
     - TOX_ENV=py34-with-tornado-falcon
     - TOX_ENV=py35
+    - TOX_ENV=py35-with-django19
+    - TOX_ENV=py35-with-django110
     - TOX_ENV=py35-with-tornado-falcon
     - TOX_ENV=flake8
 cache:

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,17 @@
 [tox]
 envlist=
     py27,
+    py27-with-django19,
+    py27-with-django110,
     py27-with-tornado-falcon,
     py2-with-webob,
     py34,
+    py34-with-django19,
+    py34-with-django110,
     py34-with-tornado-falcon,
     py35,
+    py35-with-django19,
+    py35-with-django110,
     py35-with-tornado-falcon,
     py3-with-webob,
     flake8
@@ -21,6 +27,18 @@ deps =
 
 [testenv:py27]
 basepython=python2.7
+
+[testenv:py27-with-django19]
+basepython=python2.7
+deps =
+    -r{toxinidir}/requirements-dev.txt
+    django>=1.9.0,<1.10.0
+    
+[testenv:py27-with-django110]
+basepython=python2.7
+deps =
+    -r{toxinidir}/requirements-dev.txt
+    django>=1.10.0,<1.11.0
 
 [testenv:py27-with-tornado-falcon]
 basepython=python2.7
@@ -38,6 +56,18 @@ deps =
 [testenv:py34]
 basepython=python3.4
 
+[testenv:py34-with-django19]
+basepython=python3.4
+deps =
+    -r{toxinidir}/requirements-dev.txt
+    django>=1.9.0,<1.10.0
+
+[testenv:py34-with-django110]
+basepython=python3.4
+deps =
+    -r{toxinidir}/requirements-dev.txt
+    django>=1.10.0,<1.11.0
+
 [testenv:py34-with-tornado-falcon]
 basepython=python3.4
 deps =
@@ -47,6 +77,18 @@ deps =
 
 [testenv:py35]
 basepython=python3.5
+
+[testenv:py35-with-django19]
+basepython=python3.5
+deps =
+    -r{toxinidir}/requirements-dev.txt
+    django>=1.9.0,<1.10.0
+
+[testenv:py35-with-django110]
+basepython=python3.5
+deps =
+    -r{toxinidir}/requirements-dev.txt
+    django>=1.10.0,<1.11.0
 
 [testenv:py35-with-tornado-falcon]
 basepython=python3.5


### PR DESCRIPTION
This adds django request/response normalization. I'd reckon there's still a little bit of work to be done here, e.g. documentation and perhaps rejigging the tox environments.  Also, I'm not sure how strict the django version should be or how that should be supported.

Happy to make any and all changes, I've raised as-is as it's working and I thought I there should be a discussion about the above points.  