### PR TITLE
Replace pypip.in badges with shields.io badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Build Status](https://travis-ci.org/pipermerriam/flex.png)](https://travis-ci.org/pipermerriam/flex)
 [![Documentation Status](https://readthedocs.org/projects/flex-swagger/badge/?version=latest)](https://readthedocs.org/projects/flex-swagger/?badge=latest)
-[![PyPi version](https://pypip.in/v/flex/badge.png)](https://pypi.python.org/pypi/flex)
-[![PyPi downloads](https://pypip.in/d/flex/badge.png)](https://pypi.python.org/pypi/flex)
+[![PyPi version](https://img.shields.io/pypi/v/flex.svg)](https://pypi.python.org/pypi/flex)
+[![PyPi downloads](https://img.shields.io/pypi/dm/flex.svg)](https://pypi.python.org/pypi/flex)
    
 
 Validation tooling for [Swagger 2.0](https://github.com/wordnik/swagger-spec/blob/master/versions/2.0.md) specifications.


### PR DESCRIPTION
pypip.in appears not to be functioning any more, sheilds.io provides
the same badges and is currently up.