### PR TITLE
Add support for validation of dates

### DIFF
--- a/flex/constants.py
+++ b/flex/constants.py
@@ -126,6 +126,7 @@ being present.
 EMPTY = Empty()
 
 UUID = 'uuid'
+DATE = 'date'
 DATETIME = 'date-time'
 EMAIL = 'email'
 INT32 = 'int32'

--- a/flex/error_messages.py
+++ b/flex/error_messages.py
@@ -26,6 +26,7 @@ TYPE_MESSAGES = {
 FORMAT_MESSAGES = {
     'invalid': "Value {0} does not conform to the format {1}",
     'invalid_uuid': "{0} is not a valid uuid",
+    'invalid_date': "{0} is not a valid RFC3339/ISO8601 full-date",
     'invalid_datetime': "{0} is not a valid iso8601 date-time",
     'too_many_bits': "Integer {0} has {1} bits.  Must be no more than {2} bits",
     'invalid_uri': "The value `{0}` is not valid according to RFC3987.",

--- a/flex/error_messages.py
+++ b/flex/error_messages.py
@@ -27,7 +27,7 @@ FORMAT_MESSAGES = {
     'invalid': "Value {0} does not conform to the format {1}",
     'invalid_uuid': "{0} is not a valid uuid",
     'invalid_date': "{0} is not a valid RFC3339/ISO8601 full-date",
-    'invalid_datetime': "{0} is not a valid iso8601 date-time",
+    'invalid_datetime': "{0} is not a valid RFC3339/ISO8601 date-time",
     'too_many_bits': "Integer {0} has {1} bits.  Must be no more than {2} bits",
     'invalid_uri': "The value `{0}` is not valid according to RFC3987.",
     'invalid_email': "The email address `{0}` is invalid according to RFC5322.",

--- a/flex/formats.py
+++ b/flex/formats.py
@@ -1,3 +1,4 @@
+import datetime
 import re
 
 import six
@@ -12,6 +13,7 @@ from flex.constants import (
     STRING,
     INTEGER,
     UUID,
+    DATE,
     DATETIME,
     INT32,
     INT64,
@@ -120,6 +122,14 @@ def date_time_format_validator(value, **kwargs):
         iso8601.parse_date(value)
     except iso8601.ParseError:
         raise ValidationError(MESSAGES['format']['invalid_datetime'].format(value))
+
+
+@register(DATE, STRING)
+def date_format_validator(value, **kwargs):
+    try:
+        datetime.datetime.strptime(value, '%Y-%m-%d')
+    except ValueError:
+        raise ValidationError(MESSAGES['format']['invalid_date'].format(value))
 
 
 UUID_PATTERN = re.compile(

--- a/tests/validation/parameter/test_format_validation.py
+++ b/tests/validation/parameter/test_format_validation.py
@@ -13,6 +13,7 @@ from flex.constants import (
     NUMBER,
     STRING,
     UUID,
+    DATE,
     DATETIME,
 )
 from flex.error_messages import MESSAGES
@@ -24,6 +25,7 @@ from tests.utils import assert_message_in_errors
     'format_,value,error_key',
     (
         (UUID, 'not-a-real-uuid', 'invalid_uuid'),
+        (DATE, '2017-13-02', 'invalid_date'),  # Invalid month 13
         (DATETIME, '2011-13-18T10:29:47+03:00', 'invalid_datetime'),  # Invalid month 13
     )
 )
@@ -56,6 +58,7 @@ def test_parameter_format_validation_on_invalid_values(format_, value, error_key
     'format_,value',
     (
         (UUID, '536aa369-5b29-4367-b5a4-2696565f4e8a'),
+        (DATE, '2017-02-03'),
         (DATETIME, '2011-12-18T10:29:47+03:00'),
     ),
 )

--- a/tests/validation/schema/test_format_validation.py
+++ b/tests/validation/schema/test_format_validation.py
@@ -32,6 +32,46 @@ def test_date_time_format_validation(when):
 @pytest.mark.parametrize(
     'when',
     (
+        '2017-02-03',
+    ),
+)
+def test_date_format_validation(when):
+    schema = {
+        'format': 'date',
+    }
+    validator = generate_validator_from_schema(schema)
+
+    validator(when)
+
+
+@pytest.mark.parametrize(
+    'when',
+    (
+        'not-a-date-at-all',  # not a date at all
+        '02-03-2017',
+        '02/03/2017',
+        '2017-02-0318T12:34:56',  # valid date-time, not date
+    ),
+)
+def test_date_with_invalid_dates_strings(when):
+    schema = {
+        'format': 'date',
+    }
+    validator = generate_validator_from_schema(schema)
+
+    with pytest.raises(ValidationError) as err:
+        validator(when)
+
+    assert 'format' in err.value.messages[0]
+    assert_error_message_equal(
+        err.value.messages[0]['format'][0],
+        MESSAGES['format']['invalid_date'],
+    )
+
+
+@pytest.mark.parametrize(
+    'when',
+    (
         'not-a-date-at-all',  # not a date at all
         '2011-13-18T10:29:47+03:00',  # Invalid month 13
         '2011-08-32T10:29:47+03:00',  # Invalid day 32
@@ -55,6 +95,15 @@ def test_date_time_with_invalid_dates_strings(when):
         err.value.messages[0]['format'][0],
         MESSAGES['format']['invalid_datetime'],
     )
+
+
+def test_date_is_noop_when_not_present_or_required():
+    schema = {
+        'format': 'date',
+    }
+    validator = generate_validator_from_schema(schema)
+
+    validator(EMPTY)
 
 
 def test_date_time_is_noop_when_not_present_or_required():


### PR DESCRIPTION
Swagger defines the date format, which are date (no time) strings
conforming to the full date format defined in RFC3339 (essentially
just the date portion of a full ISO8601 date/time). This adds
support for validation of this format.