### PR TITLE
Fix parameters in content type causing validation failure

### DIFF
--- a/flex/error_messages.py
+++ b/flex/error_messages.py
@@ -171,6 +171,7 @@ PATH_MESSAGES = {
 
 CONTENT_TYPE_MESSAGES = {
     'invalid': 'Invalid content type `{0}`. Must be one of `{1}`.',
+    'not_specified': 'Content type not specified. Must be be one of `{0}`',
 }
 
 

--- a/flex/validation/common.py
+++ b/flex/validation/common.py
@@ -525,3 +525,13 @@ def validate_path_to_api_path(path, paths, basePath='', context=None, **kwargs):
         raise ValidationError(str(err))
 
     return api_path
+
+
+def validate_content_type(content_type, content_types, **kwargs):
+    # TODO: is it correct to skip validation for a null content_type?
+    if content_type and content_type not in content_types:
+        raise ValidationError(
+            MESSAGES['content_type']['invalid'].format(
+                content_type, content_types,
+            ),
+        )

--- a/flex/validation/common.py
+++ b/flex/validation/common.py
@@ -528,10 +528,19 @@ def validate_path_to_api_path(path, paths, basePath='', context=None, **kwargs):
 
 
 def validate_content_type(content_type, content_types, **kwargs):
-    # TODO: is it correct to skip validation for a null content_type?
-    if content_type and content_type not in content_types:
-        raise ValidationError(
-            MESSAGES['content_type']['invalid'].format(
-                content_type, content_types,
-            ),
-        )
+    if content_type:
+        # only check MIME type, ignore parameters
+        content_type, _, _ = content_type.partition(';')
+        if content_type not in content_types:
+            raise ValidationError(
+                MESSAGES['content_type']['invalid'].format(
+                    content_type, content_types,
+                ),
+            )
+    else:
+        # according to RFC 2616 if Content-Type is missing it should be treated
+        # as application/octet-stream
+        if 'application/octet-stream' not in content_types:
+            raise ValidationError(
+                MESSAGES['content_type']['not_specified'].format(content_types)
+            )

--- a/flex/validation/operation.py
+++ b/flex/validation/operation.py
@@ -33,6 +33,7 @@ from flex.validation.common import (
     noop,
     generate_value_processor,
     generate_object_validator,
+    validate_content_type,
 )
 
 
@@ -47,13 +48,7 @@ def validate_operation(request, validators, **kwargs):
 
 def validate_request_content_type(request, content_types, **kwargs):
     assert isinstance(request, Request)
-    # TODO: is it correct to skip validation for a null content_type?
-    if request.content_type and request.content_type not in content_types:
-        raise ValidationError(
-            'Invalid content type `{0}`.  Must be one of `{1}`.'.format(
-                request.content_type, content_types,
-            ),
-        )
+    validate_content_type(request.content_type, content_types, **kwargs)
 
 
 def generate_request_content_type_validator(consumes, **kwargs):

--- a/flex/validation/response.py
+++ b/flex/validation/response.py
@@ -28,6 +28,7 @@ from flex.validation.path import (
 )
 from flex.validation.common import (
     generate_value_processor,
+    validate_content_type,
 )
 from flex.http import Response
 
@@ -100,12 +101,7 @@ def generate_response_header_validator(headers, context, **kwargs):
 
 def validate_response_content_type(response, content_types, **kwargs):
     assert isinstance(response, Response)  # TODO: remove this sanity check
-    if response.content_type and response.content_type not in content_types:
-        raise ValidationError(
-            MESSAGES['content_type']['invalid'].format(
-                response.content_type, content_types,
-            ),
-        )
+    validate_content_type(response.content_type, content_types)
 
 
 def generate_response_content_type_validator(produces, **kwargs):

--- a/tests/validation/request/test_request_content_type_validation.py
+++ b/tests/validation/request/test_request_content_type_validation.py
@@ -1,3 +1,8 @@
+import pytest
+
+from flex.error_messages import MESSAGES
+from flex.exceptions import ValidationError
+
 from flex.validation.request import (
     validate_request,
 )
@@ -6,9 +11,33 @@ from tests.factories import (
     SchemaFactory,
     RequestFactory,
 )
+from tests.utils import assert_message_in_errors
 
 
-def test_request_validation_with_invalid_operation_on_path():
+def test_request_content_type_validation():
+    schema = SchemaFactory(
+        consumes=['application/json'],
+        paths={
+            '/get': {
+                'get': {
+                    'responses': {'200': {'description': 'Success'}},
+                }
+            },
+        },
+    )
+
+    request = RequestFactory(
+        url='http://www.example.com/get',
+        content_type='application/json',
+    )
+
+    validate_request(
+        request=request,
+        schema=schema,
+    )
+
+
+def test_request_content_type_validation_when_no_content_type_specified():
     schema = SchemaFactory(
         consumes=['application/json'],
         paths={
@@ -23,6 +52,36 @@ def test_request_validation_with_invalid_operation_on_path():
     request = RequestFactory(
         url='http://www.example.com/get',
         content_type=None,
+    )
+
+    with pytest.raises(ValidationError) as err:
+        validate_request(
+            request=request,
+            schema=schema,
+        )
+
+    assert_message_in_errors(
+        MESSAGES['content_type']['not_specified'],
+        err.value.detail,
+        'method.consumes',
+    )
+
+
+def test_request_content_type_validation_ignores_parameters():
+    schema = SchemaFactory(
+        consumes=['application/json'],
+        paths={
+            '/get': {
+                'get': {
+                    'responses': {'200': {'description': 'Success'}},
+                }
+            },
+        },
+    )
+
+    request = RequestFactory(
+        url='http://www.example.com/get',
+        content_type='application/json; charset=utf-8',
     )
 
     validate_request(


### PR DESCRIPTION
The Swagger specification says that consumes and produces are "A list
of MIME types...". The Content-Type header of a HTTP request consists
of a MIME type *and* optional parameters, e.g.

    text/html; charset=utf-8

validation of request and response content type was failing when
parameters were present as the entire value of the Content-Type header
was compared to the allowed MIME types in consumes/produces.

This changes the validation of content types to only compare the MIME
type in the header to the allowed MIME types defined in consumes and
produces as appropriate for requests/responses.