### PR TITLE
Change the ranges of the int32 and int64 formats

### DIFF
--- a/flex/error_messages.py
+++ b/flex/error_messages.py
@@ -28,7 +28,9 @@ FORMAT_MESSAGES = {
     'invalid_uuid': "{0} is not a valid uuid",
     'invalid_date': "{0} is not a valid RFC3339/ISO8601 full-date",
     'invalid_datetime': "{0} is not a valid RFC3339/ISO8601 date-time",
-    'too_many_bits': "Integer {0} has {1} bits. Must be no more than {2} bits",
+    'invalid_int': (
+        "Integer {0} does not conform to the format int{1}. Must be no more than {1} bits"
+    ),
     'invalid_uri': "The value `{0}` is not valid according to RFC3987.",
     'invalid_email': "The email address `{0}` is invalid according to RFC5322.",
 }

--- a/flex/formats.py
+++ b/flex/formats.py
@@ -85,29 +85,16 @@ def uri_validator(value, **kwargs):
         raise ValidationError(MESSAGES['format']['invalid_uri'].format(value))
 
 
-def number_of_bits(n):
-    try:
-        return n.bit_length()
-    except AttributeError:
-        return len(bin(n)) - 1
-
-
 @register(INT32, INTEGER)
 def int32_validator(value, **kwargs):
-    num_bits = number_of_bits(value)
-    if num_bits > 32:
-        raise ValidationError(MESSAGES['format']['too_many_bits'].format(
-            value, num_bits, 32
-        ))
+    if value < -2147483648 or value > 2147483647:
+        raise ValidationError(MESSAGES['format']['invalid_int'].format(value, 32))
 
 
 @register(INT64, INTEGER)
 def int64_validator(value, **kwargs):
-    num_bits = number_of_bits(value)
-    if num_bits > 64:
-        raise ValidationError(MESSAGES['format']['too_many_bits'].format(
-            value, num_bits, 64
-        ))
+    if value < -9223372036854775808 or value > 9223372036854775807:
+        raise ValidationError(MESSAGES['format']['invalid_int'].format(value, 64))
 
 
 @register(EMAIL, STRING)

--- a/tests/core/test_format_validators.py
+++ b/tests/core/test_format_validators.py
@@ -79,10 +79,10 @@ def test_uuid5_matches():
         uuid_format_validator(str(uuid.uuid5(uuid.uuid1(), 'test-1')))
 
 
-MAX_INT32 = 2 ** 32 - 1
-MIN_INT32 = -1 * 2 ** 32 + 1
-MAX_INT64 = 2 ** 64 - 1
-MIN_INT64 = -1 * 2 ** 64 + 1
+MAX_INT32 = 2 ** 31 - 1
+MIN_INT32 = -1 * 2 ** 31
+MAX_INT64 = 2 ** 63 - 1
+MIN_INT64 = -1 * 2 ** 63
 
 
 #


### PR DESCRIPTION
Hi!

The int32 and int64 formats seem to be validated in ranges different from the ranges of signed integer that is often used.  The int32 format is in the range from -4,294,967,295 to 4,294,967,295, and the int64 format is in the range from -18,446,744,073,709,551,615 to 18,446,744,073,709,551,615.

I'm not sure what the specification is saying.  But I hope these ranges will be changed so that it will be 32 bits or 64 bits including the bit necessary to express the sign.

If this request is merged, the int32 format will be in the range from -2,147,483,648 to 2,147,483,647 and the int64 format will be in the range from -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807.

Thanks a lot.

![image](https://cloud.githubusercontent.com/assets/6029544/25068069/ed6f12de-2292-11e7-8f5c-5aaaec9bf31e.png)

Photo by [kristenadams](https://www.flickr.com/photos/kristenadams/3463566755/)