### PR TITLE
Do not validate Content-Type if it is missing

### DIFF
--- a/flex/validation/common.py
+++ b/flex/validation/common.py
@@ -537,10 +537,3 @@ def validate_content_type(content_type, content_types, **kwargs):
                     content_type, content_types,
                 ),
             )
-    else:
-        # according to RFC 2616 if Content-Type is missing it should be treated
-        # as application/octet-stream
-        if 'application/octet-stream' not in content_types:
-            raise ValidationError(
-                MESSAGES['content_type']['not_specified'].format(content_types)
-            )

--- a/tests/validation/request/test_request_content_type_validation.py
+++ b/tests/validation/request/test_request_content_type_validation.py
@@ -54,16 +54,10 @@ def test_request_content_type_validation_when_no_content_type_specified():
         content_type=None,
     )
 
-    with pytest.raises(ValidationError) as err:
-        validate_request(
-            request=request,
-            schema=schema,
-        )
-
-    assert_message_in_errors(
-        MESSAGES['content_type']['not_specified'],
-        err.value.detail,
-        'method.consumes',
+    # this is considered valid currently, but may change
+    validate_request(
+        request=request,
+        schema=schema,
     )
 
 

--- a/tests/validation/response/test_response_content_type_validation.py
+++ b/tests/validation/response/test_response_content_type_validation.py
@@ -54,17 +54,12 @@ def test_response_content_type_validation_when_no_content_type_specified():
         url='http://www.example.com/get',
         content_type=None,
     )
-    with pytest.raises(ValidationError) as err:
-        validate_response(
-            response=response,
-            request_method='get',
-            schema=schema,
-        )
 
-    assert_message_in_errors(
-        MESSAGES['content_type']['not_specified'],
-        err.value.detail,
-        'body.produces',
+    # this is considered valid currently, but may change
+    validate_response(
+        response=response,
+        request_method='get',
+        schema=schema,
     )
 
 


### PR DESCRIPTION
This is the behaviour flex had prior to d91debaa, in that commit the
Content-Type validation logic was changed to assume the Content-Type
of a request was application/octet-stream if it was not otherwise
given. This is not wrong per se, but as the Content-Type header is
not given with requests with no body (e.g. a GET request) this meant
that these requests were considered to have the an invalid
Content-Type when they really, correctly had provided None. This
restores the previous behaviour where, in all cases, Content-Type
was would be ignored if not provided.