### PR TITLE
Add optional raw_request param to validate_api_response

### DIFF
--- a/flex/core.py
+++ b/flex/core.py
@@ -117,13 +117,17 @@ def validate_api_request(schema, raw_request):
         validate_request(request=request, schema=schema)
 
 
-def validate_api_response(schema, raw_response, request_method='get'):
+def validate_api_response(schema, raw_response, request_method='get', raw_request=None):
     """
     Validate the response of an api call against a swagger schema.
     """
+    request = None
+    if raw_request is not None:
+        request = normalize_request(raw_request)
+
     response = None
     if raw_response is not None:
-        response = normalize_response(raw_response)
+        response = normalize_response(raw_response, request=request)
 
     if response is not None:
         validate_response(


### PR DESCRIPTION
da3ab9a3de0ef75e93a79f19efd013cfd11b2697 added the convenience method validate_api_response.  We tried using this new method in out existing django project. As the response validation needs a valid request path and django response don't know it we raise an exception if no path could be found ([http.py:L303](https://github.com/pipermerriam/flex/blob/master/flex/http.py#L303)).
Problem for us is that we can not use the convenience method as we have to supply an additional request for response validation and the method dows not allow to set a request. So I added an optional `raw_request` param which will be normalized and added to the response normalizer.