### PR TITLE
Raise flex.http.JSONDecodeEror when Request/Response JSON invalid

### DIFF
--- a/flex/http.py
+++ b/flex/http.py
@@ -92,7 +92,7 @@ class Request(URLMixin):
             return EMPTY
         elif self.content_type.startswith('application/json'):
             try:
-                if type(self.body) == bytes:
+                if isinstance(self.body, six.binary_type):
                     return json.loads(self.body.decode('utf-8'))
                 else:
                     return json.loads(self.body)

--- a/tests/http/test_response_data_propery.py
+++ b/tests/http/test_response_data_propery.py
@@ -1,0 +1,47 @@
+import pytest
+import json
+import sys
+
+import six
+
+from flex.http import JSONDecodeError
+
+from tests.factories import (
+    ResponseFactory,
+)
+
+
+@pytest.mark.skipif(sys.version_info[0:2] >= (3, 5), reason='Python35+ has json.JSONDecodeError')
+def test_py2_invalid_json():
+    body = '{"trailing comma not valid": [1,]}'
+    response = ResponseFactory(
+        content=body,
+        content_type='application/json',
+    )
+
+    try:
+        json.loads(body)
+    except ValueError as e:
+        expected_message = str(e)
+
+    with pytest.raises(JSONDecodeError) as e:
+        response.data
+    assert str(e.value) == expected_message
+
+
+@pytest.mark.skipif(sys.version_info[0:2] < (3, 5), reason='Python2-34 do not have json.JSONDecodeError')
+def test_py3_invalid_json():
+    body = '{"trailing comma not valid": [1,]}'
+    response = ResponseFactory(
+        content=body,
+        content_type='application/json',
+    )
+
+    try:
+        json.loads(body)
+    except JSONDecodeError as e:
+        expected_exception = e
+
+    with pytest.raises(JSONDecodeError) as e:
+        response.data
+    assert e.value.msg == expected_exception.msg


### PR DESCRIPTION
Python's inbuilt json module is used to parse JSON in requests and
    responses before it's checked against the schema. In Python 2 the
    json module only raises ValueError in cases where it is unable to
    parse the data, e.g.
    
        import json
        json.loads('{"not valid": [1,]}')
        >>> ValueError: No JSON object could be decoded
    
    whereas in Python 3 a JSONDecodeError is raised instead:
    
        import json
        json.loads('{"not valid": [1,]}')
        >>> JSONDecodeError: Expecting value: line 1 column 18 (char 17)
    
    In either Python version flex allows the exception to bubble, this
    makes it difficult to determine programmatically that the JSON is
    invalid in Python 2 (unless you examine the message or stack trace)
    as ValueError can be raised in many situations.
    
    This adds a custom JSONDecodeError in flex.http when run with Python 2
    which is used to wrap the message from any ValueErrors caused by
    invalid JSON, and as JSOnDecodeError is imported when run with Python 3
    - this means that users can catch flex.http.JSONDecodeError in either
    Python version and be able to tell that there was a problem parsing
    a request/response's JSON.
    
    NOTE: Request can also parse application/x-www-form-urlencoded data,
          but urlparse.parse_qsl doesn't currently raise exceptions as
          strict_parsing is false by default (so it simply returns empty
          arrays instead of raising exceptions against bad data), so
          there is no similar need to wrap exceptions for compatiblity.
