### PR TITLE
Fix response reference

### DIFF
--- a/flex/validation/response.py
+++ b/flex/validation/response.py
@@ -31,6 +31,7 @@ from flex.validation.common import (
     validate_content_type,
 )
 from flex.http import Response
+from flex.utils import dereference_reference
 
 
 def validate_status_code_to_response_definition(response, operation_definition):
@@ -158,6 +159,8 @@ def generate_response_validator(api_path, operation_definition, response_definit
         parameters=operation_definition.get('parameters', []),
         context=context,
     ))
+    if '$ref' in response_definition:
+        response_definition = dereference_reference(response_definition['$ref'], context)
 
     for key in validator_mapping:
         if key in response_definition:

--- a/tests/validation/response/test_response_reference.py
+++ b/tests/validation/response/test_response_reference.py
@@ -1,0 +1,63 @@
+import json
+import pytest
+
+from flex.exceptions import ValidationError
+from flex.validation.response import (
+    validate_response,
+)
+from flex.constants import (
+    PATH,
+    INTEGER,
+    OBJECT,
+)
+
+from tests.factories import (
+    SchemaFactory,
+    ResponseFactory,
+)
+
+from flex.error_messages import MESSAGES
+
+from tests.utils import assert_message_in_errors
+
+
+def test_response_reference():
+    schema = SchemaFactory(
+            paths={
+                '/get': {
+                    'get': {'responses': {
+                            '200':
+                                { '$ref': "#/responses/NumberResponse"},
+                            }
+                    }
+                },
+            },
+            definitions={
+                'Number': {
+                    'type': INTEGER,
+                },
+            },
+            responses={
+                'NumberResponse':
+                {'description': 'Success', 'schema': {'$ref': '#/definitions/Number'}},
+            },
+    )
+
+    response = ResponseFactory(
+            url='http://www.example.com/get',
+            status_code=200,
+            content_type='application/json',
+            content=json.dumps(None),
+    )
+
+    with pytest.raises(ValidationError) as err:
+        validate_response(
+                response=response,
+                request_method='get',
+                schema=schema,
+        )
+    assert_message_in_errors(
+            MESSAGES['type']['invalid'],
+            err.value.detail,
+            'body.schema.type',
+    )


### PR DESCRIPTION
Flex seems to ignore referenced response definitions when validating responses.
This fix properly dereference the response definition before response validation is performed.