### PR TITLE
Validate date/times are RFC3339 compliant

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -165,7 +165,7 @@ Flex implements format validation for the following formats
 * ``uuid``:
   Version 1, 3, 4, and 5
 * ``datetime``:
-  iso8601 formatted datetimes via https://pypi.python.org/pypi/iso8601.
+  RFC3339 formatted datetimes via https://pypi.python.org/pypi/strict-rfc3339.
 * ``int32``:
   Integers up to 32 bits.
 * ``int64``:

--- a/flex/error_messages.py
+++ b/flex/error_messages.py
@@ -26,8 +26,8 @@ TYPE_MESSAGES = {
 FORMAT_MESSAGES = {
     'invalid': "Value {0} does not conform to the format {1}",
     'invalid_uuid': "{0} is not a valid uuid",
-    'invalid_date': "{0} is not a valid RFC3339/ISO8601 full-date",
-    'invalid_datetime': "{0} is not a valid RFC3339/ISO8601 date-time",
+    'invalid_date': "{0} is not a valid RFC3339 full-date",
+    'invalid_datetime': "{0} is not a valid RFC3339 date-time",
     'invalid_int': (
         "Integer {0} does not conform to the format int{1}. Must be no more than {1} bits"
     ),

--- a/flex/formats.py
+++ b/flex/formats.py
@@ -3,8 +3,8 @@ import re
 
 import six
 
-import iso8601
 import rfc3987
+import strict_rfc3339
 
 from flex.utils import is_value_of_any_type
 from flex.exceptions import ValidationError
@@ -105,9 +105,7 @@ def email_validator(value, **kwargs):
 
 @register(DATETIME, STRING)
 def date_time_format_validator(value, **kwargs):
-    try:
-        iso8601.parse_date(value)
-    except iso8601.ParseError:
+    if not strict_rfc3339.validate_rfc3339(value):
         raise ValidationError(MESSAGES['format']['invalid_datetime'].format(value))
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 six>=1.7.3
 PyYAML>=3.11
-iso8601>=0.1.10
 validate-email>=1.2
 rfc3987>=1.3.4
 requests>=2.4.3
+strict-rfc3339>=0.7
 click>=3.3
 jsonpointer==1.7

--- a/setup.py
+++ b/setup.py
@@ -27,10 +27,10 @@ setup(
     install_requires=[
         "six>=1.7.3",
         "PyYAML>=3.11",
-        "iso8601>=0.1.10",
         "validate-email>=1.2",
         "rfc3987>=1.3.4",
         "requests>=2.4.3",
+        "strict-rfc3339>=0.7",
         "click>=3.3",
         "jsonpointer>=1.7",
     ],

--- a/tests/core/test_format_validators.py
+++ b/tests/core/test_format_validators.py
@@ -25,6 +25,8 @@ def test_date_time_format_validator_skips_non_string_types(value):
 @pytest.mark.parametrize(
     'value',
     (
+        '2017',  # Not a full date
+        '2017-01-02T12:34:56',  # No TZ part
         '2011-13-18T10:29:47+03:00',  # Invalid month 13
         '2011-08-32T10:29:47+03:00',  # Invalid day 32
         '2011-08-18T25:29:47+03:00',  # Invalid hour 25
@@ -42,12 +44,11 @@ def test_date_time_format_validator_detects_invalid_values(value):
     'value',
     (
         '2011-08-18T10:29:47+03:00',
-        '2011-08-18',
         '1985-04-12T23:20:50.52Z',
         '1996-12-19T16:39:57-08:00',
-        # Leap second should be valid but iso8601 doesn't correctly parse.
+        # Leap second should be valid but strict_rfc339 doesn't correctly parse.
         pytest.mark.xfail('1990-12-31T23:59:60Z'),
-        # Leap second should be valid but iso8601 doesn't correctly parse.
+        # Leap second should be valid but strict_rfc339 doesn't correctly parse.
         pytest.mark.xfail('1990-12-31T15:59:60-08:00'),
         # Weird netherlands time from strange 1909 law.
         '1937-01-01T12:00:27.87+00:20',

--- a/tests/validation/schema/test_format_validation.py
+++ b/tests/validation/schema/test_format_validation.py
@@ -17,7 +17,7 @@ from tests.utils import (
     'when',
     (
         '2011-08-18T10:29:47+03:00',
-        '2011-08-18',
+        '2017-01-02T12:34:56Z',
     ),
 )
 def test_date_time_format_validation(when):


### PR DESCRIPTION
The Swagger spec states that date/times must be in the format described
by RFC3339, this a strict subset of the ISO8601 format, essentially
requiring that date/times are of the form:

    2017-01-02T12:34:56Z
    or
    2017-01-02T12:34:56+00:00

(with microseconds allowed but optional).

Previously flex validated date/times against ISO8601, this is more
permissive than RFC3339 and so some date/time strings were considered
valid as they were valid ISO8601 date/times but were not valid
against RFC3339.

This changes date/time validation to check against the format specified
in RFC3339.