### PR TITLE
Avoid AttributeError on request/response data when Content-Type missing

### DIFF
--- a/flex/http.py
+++ b/flex/http.py
@@ -97,7 +97,7 @@ class Request(URLMixin):
             return self.body
         elif self.body is EMPTY:
             return EMPTY
-        elif self.content_type.startswith('application/json'):
+        elif self.content_type and self.content_type.startswith('application/json'):
             try:
                 if isinstance(self.body, six.binary_type):
                     return json.loads(self.body.decode('utf-8'))
@@ -316,7 +316,7 @@ class Response(URLMixin):
     def data(self):
         if self.content is EMPTY:
             return self.content
-        elif self.content_type.startswith('application/json'):
+        elif self.content_type and self.content_type.startswith('application/json'):
             try:
                 if isinstance(self.content, six.binary_type):
                     return json.loads(six.text_type(self.content, encoding='utf-8'))

--- a/tests/http/test_request_data_property.py
+++ b/tests/http/test_request_data_property.py
@@ -95,3 +95,9 @@ def test_py3_invalid_json():
     with pytest.raises(JSONDecodeError) as e:
         request.data
     assert e.value.msg == expected_exception.msg
+
+
+def test_content_type_is_none():
+    request = RequestFactory(body='some content', content_type=None)
+    with pytest.raises(NotImplementedError):
+        request.data

--- a/tests/http/test_response_data_propery.py
+++ b/tests/http/test_response_data_propery.py
@@ -45,3 +45,9 @@ def test_py3_invalid_json():
     with pytest.raises(JSONDecodeError) as e:
         response.data
     assert e.value.msg == expected_exception.msg
+
+
+def test_content_type_is_none():
+    request = ResponseFactory(content='some content', content_type=None)
+    with pytest.raises(NotImplementedError):
+        request.data


### PR DESCRIPTION
HTTP POST/PUT requests SHOULD include a Content-Type but they don't
have to, if flex tried to validate a request without a Content-Type
an AttributeError would be raised as the data property of Request
and Response checks the content_type with .startswith to see if
it's JSON (and so should be parsed before further processing). This
exception happened before any validation on Content-Type so if you
have a schema with an endpoint that consumes application/json but
you validate a request without any Content-Type you ended up with
this exception instead of some validation error.

This puts a simple guard before the .startswith call preventing the
AttributeError.