### PR TITLE
add support for text/html content_type

### DIFF
--- a/flex/http.py
+++ b/flex/http.py
@@ -328,7 +328,10 @@ class Response(URLMixin):
                     raise e
                 raise JSONDecodeError(str(e))
         elif self.content_type and self.content_type.startswith('text/html'):
-            return self.content
+            if isinstance(self.content, six.binary_type):
+                return six.text_type(self.content, encoding='utf-8')
+            else:
+                return self.content
         raise NotImplementedError("No content negotiation for this content type")
 
 

--- a/flex/http.py
+++ b/flex/http.py
@@ -327,6 +327,8 @@ class Response(URLMixin):
                     # this will only be True for Python3+
                     raise e
                 raise JSONDecodeError(str(e))
+        elif self.content_type and self.content_type.startswith('text/html'):
+            return self.content
         raise NotImplementedError("No content negotiation for this content type")
 
 


### PR DESCRIPTION
My endpoint returns text with Content-Type "text/html", and flex gives this error: "No content negotiation for this content type"

This PR adds support for the text/html Content-Type.