### PR TITLE
Get rid of deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.7"
   - "3.5"
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.5"
 env:
   global:
     - PIP_DOWNLOAD_CACHE=$HOME/.pip_cache

--- a/flex/core.py
+++ b/flex/core.py
@@ -9,7 +9,7 @@ import six
 import json
 import yaml
 
-from flex.context_managers import ErrorCollection
+from flex.context_managers import ErrorDict
 from flex.exceptions import ValidationError
 from flex.loading.definitions import (
     definitions_validator,
@@ -113,7 +113,7 @@ def validate(raw_schema, target=None, **kwargs):
 def validate_api_request(schema, raw_request):
     request = normalize_request(raw_request)
 
-    with ErrorCollection():
+    with ErrorDict():
         validate_request(request=request, schema=schema)
 
 
@@ -145,7 +145,7 @@ def validate_api_call(schema, raw_request, raw_response):
     """
     request = normalize_request(raw_request)
 
-    with ErrorCollection() as errors:
+    with ErrorDict() as errors:
         try:
             validate_request(
                 request=request,

--- a/flex/loading/schema/host.py
+++ b/flex/loading/schema/host.py
@@ -15,7 +15,7 @@ from flex.decorators import (
     skip_if_empty,
     skip_if_not_of_type,
 )
-from flex.context_managers import ErrorCollection
+from flex.context_managers import ErrorDict
 
 
 string_type_validator = generate_type_validator(STRING)
@@ -49,7 +49,7 @@ def host_validator(value, **kwargs):
         hostname = hostname[:-1]  # strip exactly one dot from the right, if present
     allowed = re.compile("(?!-)[A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
 
-    with ErrorCollection() as errors:
+    with ErrorDict() as errors:
         if not all(allowed.match(x) for x in hostname.split(".")):
             errors.add_error(
                 'invalid',

--- a/flex/loading/schema/paths/__init__.py
+++ b/flex/loading/schema/paths/__init__.py
@@ -14,7 +14,7 @@ from flex.validation.common import (
     generate_object_validator,
 )
 from flex.context_managers import (
-    ErrorCollection,
+    ErrorDict,
 )
 from .path_item import (
     path_item_validator,
@@ -24,7 +24,7 @@ from .path_item import (
 @skip_if_empty
 @skip_if_not_of_type(OBJECT)
 def validate_path_items(paths, **kwargs):
-    with ErrorCollection() as errors:
+    with ErrorDict() as errors:
         for path, path_definition in paths.items():
             # TODO: move this to its own validation function that validates the keys.
             if not path.startswith('/'):

--- a/flex/validation/common.py
+++ b/flex/validation/common.py
@@ -25,10 +25,10 @@ from flex.utils import (
     is_value_of_any_type,
     is_non_string_iterable,
     get_type_for_value,
-    chain_reduce_partial,
     cast_value_to_type,
     deep_equal,
 )
+from flex.functional import chain_reduce_partial
 from flex.paths import (
     match_path_to_api_path,
 )

--- a/flex/validation/operation.py
+++ b/flex/validation/operation.py
@@ -2,9 +2,9 @@ import functools
 
 from flex.datastructures import ValidationDict
 from flex.exceptions import ValidationError
-from flex.utils import chain_reduce_partial
+from flex.functional import chain_reduce_partial
 from flex.functional import attrgetter
-from flex.context_managers import ErrorCollection
+from flex.context_managers import ErrorDict
 from flex.http import (
     Request,
 )
@@ -38,7 +38,7 @@ from flex.validation.common import (
 
 
 def validate_operation(request, validators, **kwargs):
-    with ErrorCollection() as errors:
+    with ErrorDict() as errors:
         for key, validator in validators.items():
             try:
                 validator(request, **kwargs)

--- a/flex/validation/parameter.py
+++ b/flex/validation/parameter.py
@@ -9,7 +9,7 @@ from flex.exceptions import (
     NoParameterFound,
 )
 from flex.error_messages import MESSAGES
-from flex.context_managers import ErrorCollection
+from flex.context_managers import ErrorDict
 from flex.validation.reference import (
     LazyReferenceValidator,
 )
@@ -98,7 +98,7 @@ def validate_query_parameters(raw_query_data, query_parameters, context):
 def validate_parameters(parameter_values, parameters, context):
     validators = construct_multi_parameter_validators(parameters, context=context)
 
-    with ErrorCollection() as errors:
+    with ErrorDict() as errors:
         for key, validator in validators.items():
             try:
                 validator(parameter_values.get(key, EMPTY))

--- a/flex/validation/request.py
+++ b/flex/validation/request.py
@@ -1,5 +1,5 @@
 from flex.exceptions import ValidationError
-from flex.context_managers import ErrorCollection
+from flex.context_managers import ErrorDict
 from flex.validation.operation import (
     construct_operation_validators,
     validate_operation,
@@ -19,7 +19,7 @@ def validate_request(request, schema):
        3. validate that the request parameters conform to the parameter
           definitions for the operation definition.
     """
-    with ErrorCollection() as errors:
+    with ErrorDict() as errors:
         # 1
         try:
             api_path = validate_path_to_api_path(

--- a/flex/validation/response.py
+++ b/flex/validation/response.py
@@ -2,9 +2,9 @@ import functools
 
 from flex.datastructures import ValidationDict
 from flex.exceptions import ValidationError
-from flex.utils import chain_reduce_partial
+from flex.functional import chain_reduce_partial
 from flex.functional import attrgetter, methodcaller
-from flex.context_managers import ErrorCollection
+from flex.context_managers import ErrorDict
 from flex.validation.common import (
     validate_object,
     validate_path_to_api_path,
@@ -200,7 +200,7 @@ def validate_response(response, request_method, schema):
           schemas for the responses.
        6. headers, content-types, etc..., ???
     """
-    with ErrorCollection() as errors:
+    with ErrorDict() as errors:
         # 1
         # TODO: tests
         try:

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -12,10 +12,10 @@ from flex.utils import (
     format_errors,
     get_type_for_value,
     cast_value_to_type,
-    chain_reduce_partial,
     is_any_string_type,
     deep_equal,
 )
+from flex.functional import chain_reduce_partial
 from flex.constants import (
     NULL,
     BOOLEAN,


### PR DESCRIPTION
There are two deprecated APIs:

* https://github.com/pipermerriam/flex/blob/master/flex/context_managers.py#L9

* https://github.com/pipermerriam/flex/blob/master/flex/utils.py#L29

but flex code itself haven't been fully migrated.