### PR TITLE
fix error when query parameter defined as a Multi-CollectionFormat-Array, fix typo in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ help:
 	@echo "clean-pyc - remove Python file artifacts"
 	@echo "lint - check style with flake8"
 	@echo "test - run tests quickly with the default Python"
-	@echo "testall - run tests on every Python version with tox"
+	@echo "test-all - run tests on every Python version with tox"
 	@echo "coverage - check code coverage quickly with the default Python"
 	@echo "docs - generate Sphinx HTML documentation, including API docs"
 	@echo "release - package and upload a release"

--- a/flex/validation/common.py
+++ b/flex/validation/common.py
@@ -423,6 +423,12 @@ def apply_validator_to_array(values, validator, **kwargs):
                 errors.add_error(err.detail)
 
 
+def add_string_into_list(raw_query_data):
+    if isinstance(raw_query_data, six.string_types):
+        return [raw_query_data]
+    return raw_query_data
+
+
 @suffix_reserved_words
 def generate_value_processor(type_, collectionFormat=None, items=None, **kwargs):
     """
@@ -445,6 +451,7 @@ def generate_value_processor(type_, collectionFormat=None, items=None, **kwargs)
             else:
                 if collectionFormat != MULTI:
                     raise TypeError("collectionFormat not implemented")
+                processors.append(add_string_into_list)
             # remove any Falsy values like empty strings.
             processors.append(functools.partial(filter, bool))
             # strip off any whitespace

--- a/tests/validation/request/test_request_query_parameter_validation.py
+++ b/tests/validation/request/test_request_query_parameter_validation.py
@@ -7,6 +7,7 @@ from flex.constants import (
     QUERY,
     STRING,
     INTEGER,
+    ARRAY
 )
 
 from tests.factories import (
@@ -45,6 +46,52 @@ def test_request_query_parameter_validation_with_no_declared_parameters():
     )
 
     request = RequestFactory(url='http://www.example.com/get/3/?page=3')
+
+    validate_request(
+        request=request,
+        schema=schema,
+    )
+
+
+def test_request_query_parameter_validation_with_array_by_multi():
+    """
+    Ensure that when a query parameter is present with no definition within the
+    schema that it is ignored.  We need to have at least one parameter at play
+    to trigger parameter validation to happen for this endpoint.
+    """
+    schema = SchemaFactory(
+        parameters = {
+            'status': {
+                'name': 'status',
+                'in': QUERY,
+                'description': 'status',
+                'required': True,
+                'type': ARRAY,
+                "items": {
+                    "type": "string",
+                    "enum": [
+                        "available",
+                        "pending",
+                        "sold"
+                    ],
+                    "default": "available"
+                },
+                "collectionFormat": "multi"
+            },
+        },
+        paths={
+            '/get': {
+                'parameters': [
+                    {'$ref': '#/parameters/status'},
+                ],
+                'get': {
+                    'responses': {200: {'description': "Success"}},
+                },
+            },
+        },
+    )
+
+    request = RequestFactory(url='http://www.example.com/get?status=sold')
 
     validate_request(
         request=request,


### PR DESCRIPTION
1.  when a query parameter defined as an array with collection format: multi and it's value contains only one item, the only item will be split into a list with each charactor as an item. see the test case i added.
2.  the help message in Makefile contains a "testall" command, but actually it should be "test-all"