### PR TITLE
Fix allOf validation #146

### DIFF
--- a/flex/core.py
+++ b/flex/core.py
@@ -4,6 +4,7 @@ from six.moves import urllib_parse as urlparse
 import os
 import collections
 import requests
+from copy import deepcopy
 
 import six
 import json
@@ -42,7 +43,7 @@ def load_source(source):
         - yaml string.
     """
     if isinstance(source, collections.Mapping):
-        return source
+        return deepcopy(source)
     elif hasattr(source, 'read') and callable(source.read):
         raw_source = source.read()
     elif os.path.exists(os.path.expanduser(str(source))):

--- a/flex/validation/common.py
+++ b/flex/validation/common.py
@@ -325,19 +325,7 @@ def validate_allof_anyof(value, sub_schemas, context, method, **kwargs):
 
 
 def generate_allof_validator(allOf, context, **kwargs):
-    context.setdefault('resolved_refs', [])
-    unresolved_refs = []
-    for ref in allOf:
-        if isinstance(ref, dict) and '$ref' in ref:
-            schema = ref['$ref']
-            if schema not in context['resolved_refs']:
-                unresolved_refs.append(ref)
-                context['resolved_refs'].append(schema)
-        else:
-            unresolved_refs.append(ref)
-
-    return functools.partial(validate_allof_anyof, sub_schemas=unresolved_refs,
-                             context=context, method=all)
+    return functools.partial(validate_allof_anyof, sub_schemas=allOf, context=context, method=all)
 
 
 def generate_anyof_validator(anyOf, context, **kwargs):
@@ -390,6 +378,8 @@ def validate_object(obj, field_validators=None, non_field_validators=None,
 
     if 'discriminator' in schema:
         schema_validators = add_polymorphism_requirements(obj, schema, context, schema_validators)
+        # delete resolved discriminator to avoid infinite recursion
+        del schema['discriminator']
 
     schema_validators.update(field_validators)
     schema_validators.validate_object(obj, context=context)

--- a/tests/core/test_load_source.py
+++ b/tests/core/test_load_source.py
@@ -16,6 +16,7 @@ def test_native_mapping_is_passthrough():
     result = load_source(source)
 
     assert result == source
+    assert result is not source
 
 
 def test_json_string():


### PR DESCRIPTION
This PR

- adds a (previously failing) unit test for #146
- reverts generate_allof_validator to its original state for correct validation
- remove the discriminator key if discriminator is resolved to stop infinite recursion

Fixes #146 