### PR TITLE
Fix flake8 test

### DIFF
--- a/flex/loading/definitions/__init__.py
+++ b/flex/loading/definitions/__init__.py
@@ -41,7 +41,7 @@ definitions_schema = {
 def validate_deferred_references(schema, context, **kwargs):
     try:
         deferred_references = context['deferred_references']
-    except:
+    except BaseException:
         raise KeyError("`deferred_references` not found in context")
 
     with ErrorDict() as errors:


### PR DESCRIPTION
Fix test by adding BaseException to an empty except clause.
The tests for #183 are shown as failed because of this.