### PR TITLE
Pass on request headers when normalizing a requests request

### DIFF
--- a/flex/http.py
+++ b/flex/http.py
@@ -147,6 +147,7 @@ def _normalize_requests_request(request):
         method=method,
         content_type=content_type,
         request=request,
+        headers=request.headers,
     )
 
 


### PR DESCRIPTION
Request header validation always fails if running "validate_api_call" with a requests request. This is because request headers are not passed along in the normalize method.

![otter](https://d1u5p3l4wpay3k.cloudfront.net/arksurvivalevolved_gamepedia/thumb/b/bd/Otter_PaintRegion4.jpg/400px-Otter_PaintRegion4.jpg "Otter")