### PR TITLE
Handle x nullable for enums

### DIFF
--- a/flex/constants.py
+++ b/flex/constants.py
@@ -115,6 +115,7 @@ SECURITY_FLOWS = (
 
 
 class Empty(object):
+
     def __cmp__(self, other):
         raise TypeError('Empty cannot be compared to other values')
 
@@ -157,3 +158,6 @@ HEAD = 'head'
 PATCH = 'patch'
 
 REQUEST_METHODS = (GET, PUT, POST, DELETE, OPTIONS, HEAD, PATCH)
+
+# Environment variables
+FLEX_DISABLE_X_NULLABLE = 'FLEX_DISABLE_X_NULLABLE'

--- a/flex/validation/common.py
+++ b/flex/validation/common.py
@@ -6,7 +6,7 @@ import functools
 import collections
 import itertools
 import json
-
+import os
 import six
 
 
@@ -41,6 +41,7 @@ from flex.constants import (
     OBJECT,
     DELIMETERS,
     REQUEST_METHODS,
+    FLEX_DISABLE_X_NULLABLE,
 )
 from flex.decorators import (
     skip_if_not_of_type,
@@ -297,7 +298,7 @@ def validate_enum(value, options, **kwargs):
 
 
 def generate_enum_validator(enum, **kwargs):
-    if kwargs.get('x-nullable') is True:
+    if not os.environ.get(FLEX_DISABLE_X_NULLABLE) and kwargs.get('x-nullable') is True:
         enum.append(None)
     return functools.partial(validate_enum, options=enum)
 

--- a/flex/validation/common.py
+++ b/flex/validation/common.py
@@ -6,6 +6,7 @@ import functools
 import collections
 import itertools
 import json
+
 import os
 import six
 
@@ -298,7 +299,7 @@ def validate_enum(value, options, **kwargs):
 
 
 def generate_enum_validator(enum, **kwargs):
-    if not os.environ.get(FLEX_DISABLE_X_NULLABLE) and kwargs.get('x-nullable') is True:
+    if FLEX_DISABLE_X_NULLABLE not in os.environ and kwargs.get('x-nullable') is True:
         enum.append(None)
     return functools.partial(validate_enum, options=enum)
 

--- a/flex/validation/common.py
+++ b/flex/validation/common.py
@@ -67,7 +67,7 @@ def generate_type_validator(type_, **kwargs):
     Generates a callable validator for the given type or iterable of types.
     """
     if is_non_string_iterable(type_):
-        types = type_
+        types = tuple(type_)
     else:
         types = (type_,)
     # support x-nullable since Swagger 2.0 doesn't support null type
@@ -297,6 +297,8 @@ def validate_enum(value, options, **kwargs):
 
 
 def generate_enum_validator(enum, **kwargs):
+    if kwargs.get('x-nullable') is True:
+        enum.append(None)
     return functools.partial(validate_enum, options=enum)
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,8 +2,6 @@ import functools
 import collections
 import re
 import six
-import contextlib
-import os
 from flex.validation.common import validate_object
 from flex.loading.schema.paths.path_item.operation.responses.single.schema import (
     schema_validator,
@@ -165,14 +163,3 @@ def generate_validator_from_schema(raw_schema, **kwargs):
     schema = schema_validator(raw_schema, **kwargs)
     validator = functools.partial(validate_object, schema=schema, **kwargs)
     return validator
-
-
-@contextlib.contextmanager
-def set_env(**environ):
-    old_environ = dict(os.environ)
-    os.environ.update(environ)
-    try:
-        yield
-    finally:
-        os.environ.clear()
-        os.environ.update(old_environ)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,7 +2,8 @@ import functools
 import collections
 import re
 import six
-
+import contextlib
+import os
 from flex.validation.common import validate_object
 from flex.loading.schema.paths.path_item.operation.responses.single.schema import (
     schema_validator,
@@ -164,3 +165,14 @@ def generate_validator_from_schema(raw_schema, **kwargs):
     schema = schema_validator(raw_schema, **kwargs)
     validator = functools.partial(validate_object, schema=schema, **kwargs)
     return validator
+
+
+@contextlib.contextmanager
+def set_env(**environ):
+    old_environ = dict(os.environ)
+    os.environ.update(environ)
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(old_environ)

--- a/tests/validation/parameter/test_enum_validation.py
+++ b/tests/validation/parameter/test_enum_validation.py
@@ -27,14 +27,17 @@ from tests.utils import assert_message_in_errors
         ([True, False], 0),
         ([True, False], 1),
         ([True, False], ''),
+        ([True, False], None),
         ([0, 1, 2, 3], True),
         ([0, 1, 2, 3], False),
         ([0, 1, 2, 3], '1'),
         ([0, 1, 2, 3], 4),
         ([0, 1, 2, 3], 1.0),
+        ([0, 1, 2, 3], None),
         (['1', '2', 'a', 'b'], 'A'),
         (['1', '2', 'a', 'b'], 1),
         (['1', '2', 'a', 'b'], 2),
+        (['1', '2', 'a', 'b'], None),
     ),
 )
 def test_enum_validation_with_invalid_values(enum, value):
@@ -82,6 +85,36 @@ def test_enum_validation_with_allowed_values(enum, value):
             'type': [STRING, NUMBER, BOOLEAN],
             'required': True,
             'enum': enum,
+        },
+    ])
+    parameter_values = {
+        'id': value,
+    }
+
+    validate_parameters(parameter_values, parameters, {})
+
+
+@pytest.mark.parametrize(
+    'enum,value',
+    (
+        ([True, False], True),
+        ([True, False], None),
+        ([0, 1, 2, 3], 1),
+        ([0, 1, 2, 3], None),
+        (['1', '2', 'a', 'b'], 'a'),
+        (['1', '2', 'a', 'b'], None),
+    ),
+)
+def test_nullable_enum_validation_with_allowed_values(enum, value):
+    parameters = parameters_validator([
+        {
+            'name': 'id',
+            'in': PATH,
+            'description': 'id',
+            'type': [STRING, NUMBER, BOOLEAN],
+            'required': True,
+            'enum': enum,
+            'x-nullable': True
         },
     ])
     parameter_values = {

--- a/tests/validation/parameter/test_enum_validation.py
+++ b/tests/validation/parameter/test_enum_validation.py
@@ -1,4 +1,5 @@
 import pytest
+import os
 
 from flex.exceptions import ValidationError
 from flex.loading.schema.paths.path_item.operation.parameters import (
@@ -16,7 +17,7 @@ from flex.constants import (
 )
 from flex.error_messages import MESSAGES
 
-from tests.utils import assert_message_in_errors, set_env
+from tests.utils import assert_message_in_errors
 
 
 #
@@ -133,7 +134,7 @@ def test_nullable_enum_validation_with_allowed_values(enum, value):
         (['1', '2', 'a', 'b'], None),
     ),
 )
-def test_nullable_enum_with_null_values_strict(enum, value):
+def test_nullable_enum_with_null_values_strict(enum, value, monkeypatch):
 
     parameters = parameters_validator([
         {
@@ -150,15 +151,15 @@ def test_nullable_enum_with_null_values_strict(enum, value):
         'id': value,
     }
 
-    with set_env(**{FLEX_DISABLE_X_NULLABLE: '1'}):
-        with pytest.raises(ValidationError) as err:
-            validate_parameters(parameter_values, parameters, {})
+    monkeypatch.setattr(os, 'environ', {FLEX_DISABLE_X_NULLABLE: '1'})
+    with pytest.raises(ValidationError) as err:
+        validate_parameters(parameter_values, parameters, {})
 
-        assert_message_in_errors(
-            MESSAGES['enum']['invalid'],
-            err.value.detail,
-            'id.enum',
-        )
+    assert_message_in_errors(
+        MESSAGES['enum']['invalid'],
+        err.value.detail,
+        'id.enum',
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/validation/parameter/test_enum_validation.py
+++ b/tests/validation/parameter/test_enum_validation.py
@@ -42,7 +42,7 @@ def test_enum_validation_with_invalid_values(enum, value):
         {
             'name': 'id',
             'in': PATH,
-            'description':'id',
+            'description': 'id',
             'type': [STRING, NUMBER, BOOLEAN],
             'required': True,
             'enum': enum,
@@ -62,7 +62,6 @@ def test_enum_validation_with_invalid_values(enum, value):
     )
 
 
-
 @pytest.mark.parametrize(
     'enum,value',
     (
@@ -79,7 +78,7 @@ def test_enum_validation_with_allowed_values(enum, value):
         {
             'name': 'id',
             'in': PATH,
-            'description':'id',
+            'description': 'id',
             'type': [STRING, NUMBER, BOOLEAN],
             'required': True,
             'enum': enum,


### PR DESCRIPTION
I've noticed that enums don't work very well with x-nullable=True. I had to include null/None as an enum value for the validation to pass, but that combo of x-nullable and enum value does not work with swagger-ui. 
So I suggest this change.
![costumes-for-dogs-banana-dog](https://user-images.githubusercontent.com/7657952/35097383-27fc4d4e-fc50-11e7-9202-a522a6f2c489.jpg)
