### PR TITLE
Ensure that werkzeug.local exists

### DIFF
--- a/flex/http.py
+++ b/flex/http.py
@@ -49,6 +49,7 @@ else:
 
 try:
     import werkzeug
+    from werkzeug import local  # make sure werkzeug.local exists
 except ImportError:
     _werkzeug_available = False
 else:

--- a/flex/http.py
+++ b/flex/http.py
@@ -252,7 +252,7 @@ def _normalize_werkzeug_request(request):
     if not _werkzeug_available:
         raise TypeError("werkzeug is not installed")
 
-    if not isinstance(request, (werkzeug.wrappers.BaseRequest, werkzeug.local.LocalProxy)):
+    if not isinstance(request, (werkzeug.wrappers.BaseRequest, local.LocalProxy)):
         raise TypeError("Cannot normalize this request object")
 
     return Request(


### PR DESCRIPTION
werkzeug.local is only created on-demand, so it may not yet exist when we try to use it.

The bug can be triggered like this (assuming a fresh Python interpreter):
```
from flex.core import load, validate_api_call
schema = load("https://raw.githubusercontent.com"
              "/OAI/OpenAPI-Specification/master/examples/v2.0/json/petstore.json")

validate_api_call(schema, raw_request={}, raw_response={})
```
This produces `AttributeError: module 'werkzeug' has no attribute 'local'` due to the following behaviour of werkzeug:
```
>>> import werkzeug
>>> werkzeug.local
Traceback (most recent call last):
...
AttributeError: module 'werkzeug' has no attribute 'local'
>>> from werkzeug import local
>>> werkzeug.local
<module 'werkzeug.local'....>
```