### PR TITLE
Fix Django response normalization failing when no Content-Type

### DIFF
--- a/flex/http.py
+++ b/flex/http.py
@@ -352,7 +352,7 @@ def _normalize_django_response(response, request=None):
         content=response.content,
         url=url,
         status_code=response.status_code,
-        content_type=response['Content-Type'],
+        content_type=response.get('Content-Type'),
         response=response)
 
 

--- a/tests/http/test_request_normalization.py
+++ b/tests/http/test_request_normalization.py
@@ -179,6 +179,10 @@ def test_django_request_normalization(httpbin):
     assert request.url == httpbin.url + '/get?key=val'
     assert request.method == 'get'
 
+    del raw_request.META['CONTENT_TYPE']
+    request = normalize_request(raw_request)
+    assert request.content_type is None
+
 
 @pytest.mark.skipif(not _werkzeug_available, reason="werkzeug not installed")
 def test_werkzeug_request_normalization(httpbin):

--- a/tests/http/test_response_normalization.py
+++ b/tests/http/test_response_normalization.py
@@ -131,6 +131,11 @@ def test_django_response_normalization(httpbin):
     assert response.url == httpbin.url + '/get?key=val'
     assert response.status_code == '200'
 
+    del raw_response._headers['content-type']
+
+    response = normalize_response(raw_response, raw_request)
+    assert response.content_type is None
+
     redirect_url = 'http://www.example.org'
     raw_response = django.http.response.HttpResponseRedirect(redirect_url)
 


### PR DESCRIPTION
Also add a test for requests without Content-Type (behavior was
already correct).

Fixes: https://github.com/pipermerriam/flex/issues/195