### PR TITLE
aiohttp request and response normalization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,8 @@ matrix:
       env: TOX_ENV=py35-with-tornado-falcon
     - python: "3.5"
       env: TOX_ENV=py35-with-werkzeug
+    - python: "3.5"
+      env: TOX_ENV=py35-with-aiohttp
     # 3.6
     - python: "3.6"
       env: TOX_ENV=py36
@@ -55,6 +57,8 @@ matrix:
       env: TOX_ENV=py36-with-tornado-falcon
     - python: "3.6"
       env: TOX_ENV=py36-with-werkzeug
+    - python: "3.6"
+      env: TOX_ENV=py36-with-aiohttp
     # flake8
     - python: "3.5"
       env: TOX_ENV=flake8

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -149,14 +149,16 @@ Request validation supports the following request objects.
 * ``urllib2.Request`` from the ``urllib2`` module of the standard library.
 * ``django.http.request.HttpRequest`` from ``django``.
 * ``werkzeug.wrappers.Request`` from ``werkzeug`` (on which ``flask`` is based).
+* ``aiohttp.web.Request`` from the ``aiohttp`` library
 
-Response valdation supports the following respone objects.
+Response validation supports the following response objects.
 
 * ``requests.Response`` from Kenneth Reitz' ``requests`` library.
 * The return value of ``urllib.urlopen`` and ``urllib2.urlopen`` from the
   standard library urllib modules.
 * ``django.http.response.HttpResponse`` from ``django``.
 * ``werkzeug.wrappers.Response`` from ``werkzeug`` (on which ``flask`` is based).
+* ``aiohttp.web.Response`` from the ``aiohttp`` library
 
 
 Formats

--- a/flex/http.py
+++ b/flex/http.py
@@ -55,6 +55,13 @@ except ImportError:
 else:
     _werkzeug_available = True
 
+try:
+    import aiohttp.web
+except ImportError:
+    _aiohttp_available = False
+else:
+    _aiohttp_available = True
+
 
 class URLMixin(object):
     @property
@@ -264,6 +271,23 @@ def _normalize_werkzeug_request(request):
     )
 
 
+def _normalize_aiohttp_request(request):
+    if not _aiohttp_available:
+        raise TypeError("aiohttp is not installed")
+
+    if not isinstance(request, aiohttp.web.Request):
+        raise TypeError("Cannot normalize this request object")
+
+    return Request(
+        url=str(request.url),
+        method=request.method,
+        content_type=request.content_type,
+        body=request.content,
+        request=request,
+        headers=request.headers,
+    )
+
+
 REQUEST_NORMALIZERS = (
     _normalize_django_request,
     _normalize_python2_urllib_request,
@@ -273,6 +297,7 @@ REQUEST_NORMALIZERS = (
     _normalize_tornado_request,
     _normalize_falcon_request,
     _normalize_werkzeug_request,
+    _normalize_aiohttp_request,
 )
 
 
@@ -461,6 +486,27 @@ def _normalize_werkzeug_response(response, request=None):
     )
 
 
+def _normalize_aiohttp_response(response, request=None):
+    if not _aiohttp_available:
+        raise TypeError("aiohttp is not installed")
+
+    if not isinstance(response, aiohttp.web.Response):
+        raise TypeError("Cannot normalize this request object")
+
+    if not isinstance(request, Request):
+        raise TypeError("Cannot normalize this response object")
+
+    return Response(
+        request=request,
+        content=response.text,
+        url=str(request.url),
+        status_code=response.status,
+        content_type=response.content_type,
+        headers=response.headers,
+        response=response,
+    )
+
+
 RESPONSE_NORMALIZERS = (
     _normalize_django_response,
     _normalize_urllib_response,
@@ -468,6 +514,7 @@ RESPONSE_NORMALIZERS = (
     _normalize_webob_response,
     _normalize_tornado_response,
     _normalize_werkzeug_response,
+    _normalize_aiohttp_response,
 )
 
 

--- a/tests/http/test_request_normalization.py
+++ b/tests/http/test_request_normalization.py
@@ -8,7 +8,7 @@ import requests
 
 from flex.http import (
     normalize_request, _tornado_available, _falcon_available, _webob_available,
-    _django_available, _werkzeug_available
+    _django_available, _werkzeug_available, _aiohttp_available
 )
 
 
@@ -205,3 +205,19 @@ def test_werkzeug_request_normalization(httpbin):
     assert request.url == httpbin.url + '/put?key=val'
     assert request.method == 'put'
     assert request.data == {'key2': 'val2'}
+
+
+@pytest.mark.skipif(not _aiohttp_available, reason="aiohttp not installed")
+def test_aiohttp_request_normalization():
+    from aiohttp.test_utils import make_mocked_request
+
+    raw_request = make_mocked_request(
+        'PUT', '/put', headers={'Content-Type': 'application/json'}, payload=b'{"key2": "val2"}'
+    )
+    request = normalize_request(raw_request)
+
+    assert request.path == '/put'
+    assert request.method == 'PUT'
+    assert request.content_type == 'application/json'
+    assert request.data == {'key2': 'val2'}
+    assert request.headers.get('Content-Type') == 'application/json'

--- a/tox.ini
+++ b/tox.ini
@@ -19,12 +19,14 @@ envlist=
     py35-with-django111,
     py35-with-tornado-falcon,
     py35-with-werkzeug,
+    py35-with-aiohttp,
     py36,
     py36-with-django19,
     py36-with-django110,
     py36-with-django111,
     py36-with-tornado-falcon,
     py36-with-werkzeug,
+    py36-with-aiohttp,
     py3-with-webob,
     flake8
 
@@ -145,6 +147,12 @@ deps =
     -r{toxinidir}/requirements-dev.txt
     werkzeug
 
+[testenv:py35-with-aiohttp]
+basepython=python3.5
+deps =
+    -r{toxinidir}/requirements-dev.txt
+    aiohttp
+
 [testenv:py36]
 basepython=python3.6
 
@@ -178,6 +186,12 @@ basepython=python3.6
 deps =
     -r{toxinidir}/requirements-dev.txt
     werkzeug
+
+[testenv:py36-with-aiohttp]
+basepython=python3.6
+deps =
+    -r{toxinidir}/requirements-dev.txt
+    aiohttp
 
 [testenv:py3-with-webob]
 basepython=python3.5


### PR DESCRIPTION
Support validating aiohttp requests and responses!

CI and linter are green. Also updated the docs.

The test cases mock requests and responses, rather than make actual requests, since it's not trivial to get async code running in the test suite.

Looking forward to your feedback.