### PR TITLE
optional space in mimetype before parameters

### DIFF
--- a/flex/loading/common/mimetypes.py
+++ b/flex/loading/common/mimetypes.py
@@ -25,7 +25,7 @@ MIMETYPE_PATTERN = (
     '(vnd(\.[-a-zA-Z0-9]+)*\.)?'  # vendor tree
     '([-a-zA-Z0-9]+)'  # media type
     '(\+(xml|json|ber|der|fastinfoset|wbxml|zip))?'
-    '((; [-a-zA-Z0-9]+=(([-\.a-zA-Z0-9]+)|(("|\')[-\.a-zA-Z0-9]+("|\'))))+)?'  # parameters
+    '((; ?[-a-zA-Z0-9]+=(([-\.a-zA-Z0-9]+)|(("|\')[-\.a-zA-Z0-9]+("|\'))))+)?'  # parameters
     '$'
 )
 


### PR DESCRIPTION
RFC7231 (https://tools.ietf.org/html/rfc7231#section-5.3.2)
does not specify that space after ; character is required.
As a matter of fact, in some examples in RFC it provides
examples without space after ; character.