### PR TITLE
pytest: replaced deprecated pytest.mark.xfail usage

### DIFF
--- a/tests/core/test_example_schemas.py
+++ b/tests/core/test_example_schemas.py
@@ -9,9 +9,9 @@ DIR = os.path.dirname(os.path.abspath(__file__))
 @pytest.mark.parametrize(
     'path',
     (
-        pytest.mark.xfail(os.path.join(DIR, 'example_schemas/uber.yaml')),
-        pytest.mark.xfail(os.path.join(DIR, 'example_schemas/petstore.yaml')),
-        pytest.mark.xfail(os.path.join(DIR, 'example_schemas/petstore-expanded.yaml')),
+        pytest.param(os.path.join(DIR, 'example_schemas/uber.yaml'), marks=pytest.mark.xfail),
+        pytest.param(os.path.join(DIR, 'example_schemas/petstore.yaml'), marks=pytest.mark.xfail),
+        pytest.param(os.path.join(DIR, 'example_schemas/petstore-expanded.yaml'), marks=pytest.mark.xfail),
         os.path.join(DIR, 'example_schemas/api-with-examples.yaml'),
     )
 )

--- a/tests/core/test_format_validators.py
+++ b/tests/core/test_format_validators.py
@@ -47,9 +47,9 @@ def test_date_time_format_validator_detects_invalid_values(value):
         '1985-04-12T23:20:50.52Z',
         '1996-12-19T16:39:57-08:00',
         # Leap second should be valid but strict_rfc339 doesn't correctly parse.
-        pytest.mark.xfail('1990-12-31T23:59:60Z'),
+        pytest.param('1990-12-31T23:59:60Z', marks=pytest.mark.xfail),
         # Leap second should be valid but strict_rfc339 doesn't correctly parse.
-        pytest.mark.xfail('1990-12-31T15:59:60-08:00'),
+        pytest.param('1990-12-31T15:59:60-08:00', marks=pytest.mark.xfail),
         # Weird netherlands time from strange 1909 law.
         '1937-01-01T12:00:27.87+00:20',
     )


### PR DESCRIPTION
Next master build on Travis [should fail](https://travis-ci.org/javabrett/flex/jobs/457318305#L521):

```
E   _pytest.warning_types.RemovedInPytest4Warning: Applying marks directly to parameters is deprecated, please use pytest.param(..., marks=...) instead.
E   For more details, see: https://docs.pytest.org/en/latest/parametrize.html
```

... as `pytest` 4.0 has been released and has some deprecation around `pytest.mark.xfail` API.

Rescued this commit from #209.