### PR TITLE
Move flake8 tests to top first

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ python:
   - "3.6"
 matrix:
   include:
+    # flake8
+    - python: "3.5"
+      env: TOX_ENV=flake8
     # 2.7
     - python: "2.7"
       env: TOX_ENV=py27
@@ -55,9 +58,6 @@ matrix:
       env: TOX_ENV=py36-with-tornado-falcon
     - python: "3.6"
       env: TOX_ENV=py36-with-werkzeug
-    # flake8
-    - python: "3.5"
-      env: TOX_ENV=flake8
 cache:
   pip: true
 install:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
-# This library is no longer maintained
+# FLEX
 
-This library currently has no dedicated maintainer and will not be receiving any updates.
+[![Build Status](https://travis-ci.org/pipermerriam/flex.png)](https://travis-ci.org/pipermerriam/flex)
+[![Documentation Status](https://readthedocs.org/projects/flex-swagger/badge/?version=latest)](https://readthedocs.org/projects/flex-swagger/?badge=latest)
+[![PyPi version](https://img.shields.io/pypi/v/flex.svg)](https://pypi.python.org/pypi/flex)
+[![PyPi downloads](https://img.shields.io/pypi/dm/flex.svg)](https://pypi.python.org/pypi/flex)
+   
+
+Validation tooling for [Swagger 2.0](https://github.com/wordnik/swagger-spec/blob/master/versions/2.0.md) specifications.
+
+
+[Documentation on ReadTheDocs](http://flex-swagger.readthedocs.org/en/latest/)
+
+## Features
+
+* Validate swagger schemas.
+* JSON Schema Validation
+* Validation of request/response objects against schema.
+* Command Line interface.
+
+
+# CLI Name Change
+
+Starting in version 5.0.0 the CLI interface has been changed to `swagger-flex`
+due to a collission with the Apache Flex project.


### PR DESCRIPTION
It's rather annoying to have all of the actual code tests pass, only for CI to fail due to flake8 complaining.

This PR rearranges the order of tests so Travis executes the flake8 tests first. This should help speed up PRs that pass code tests but fail flake8.

I also update the README to remove the "unmaintained" status of the project, since I'm now the maintainer.