### PR TITLE
Remove Python 3.3 classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
Tests aren't run against Python 3.3

![](https://media2.giphy.com/media/EExhQTbQ75Hxq3KcOp/giphy-downsized-medium.gif)