### PR TITLE
Fix typo in MINIMUM_AND_MAXIMUM_MESSAGES['invalid']

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -75,7 +75,7 @@ A subset of the ``flex`` tooling implements JSON schema validation.
    ValueError: Invalid:
    'age':
        - 'minimum':
-           - u'-5 must be greater than than 0.0'
+           - u'-5 must be greater than 0.0'
    'name':
        - 'minLength':
            - u'Ensure this value has at least 3 characters (it has 2).'

--- a/flex/error_messages.py
+++ b/flex/error_messages.py
@@ -47,7 +47,7 @@ MULTIPLE_OF_MESSAGES = {
 }
 
 MINIMUM_AND_MAXIMUM_MESSAGES = {
-    'invalid': "{0} must be {1} than {2}",
+    'invalid': "{0} must be {1} {2}",
     'must_be_greater_than_minimum': (
         "The value of `maximum` must be greater than or equal to the value of `minimum`"
     ),


### PR DESCRIPTION
"than" is superflous. Fixes #208.