### PR TITLE
Fix invalid escape sequence deprecation warnings

### DIFF
--- a/flex/loading/common/mimetypes.py
+++ b/flex/loading/common/mimetypes.py
@@ -23,11 +23,11 @@ MIMETYPE_PATTERN = (
     # https://www.iana.org/assignments/media-types/media-types.xhtml
     '(application|audio|example|font|image|message|model|multipart|text|video)'  # media type
     '/'
-    '(vnd(\.[-a-zA-Z0-9]+)*\.)?'  # vendor tree
+    r'(vnd(\.[-a-zA-Z0-9]+)*\.)?'  # vendor tree
     '([-a-zA-Z0-9]+)'  # media subtype
     # https://www.iana.org/assignments/media-type-structured-suffix/media-type-structured-suffix.xml
-    '(\+(xml|json|ber|cbor|der|fastinfoset|wbxml|zip|tlv|json-seq|sqlite3|jwt|gzip))?'
-    '((; ?[-a-zA-Z0-9]+=(([-\.a-zA-Z0-9]+)|(("|\')[-\.a-zA-Z0-9]+("|\'))))+)?'  # parameters
+    r'(\+(xml|json|ber|cbor|der|fastinfoset|wbxml|zip|tlv|json-seq|sqlite3|jwt|gzip))?'
+    r'((; ?[-a-zA-Z0-9]+=(([-\.a-zA-Z0-9]+)|(("|\')[-\.a-zA-Z0-9]+("|\'))))+)?'  # parameters
     '$'
 )
 

--- a/flex/loading/schema/host.py
+++ b/flex/loading/schema/host.py
@@ -47,7 +47,7 @@ def host_validator(value, **kwargs):
         return False
     if hostname[-1] == ".":
         hostname = hostname[:-1]  # strip exactly one dot from the right, if present
-    allowed = re.compile("(?!-)[A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
+    allowed = re.compile(r"(?!-)[A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
 
     with ErrorDict() as errors:
         if not all(allowed.match(x) for x in hostname.split(".")):

--- a/flex/paths.py
+++ b/flex/paths.py
@@ -18,9 +18,9 @@ from flex.parameters import (
 
 
 REGEX_REPLACEMENTS = (
-    ('\.', '\.'),
-    ('\{', '\{'),
-    ('\}', '\}'),
+    (r'\.', r'\.'),
+    (r'\{', r'\{'),
+    (r'\}', r'\}'),
 )
 
 
@@ -39,7 +39,7 @@ def escape_regex_special_chars(api_path):
 
 # matches the parametrized parts of a path.
 # eg. /{id}/ matches the `{id}` part of it.
-PARAMETER_REGEX = re.compile('(\{[^\}]+})')
+PARAMETER_REGEX = re.compile(r'(\{[^\}]+})')
 
 
 def construct_parameter_pattern(parameter):
@@ -53,7 +53,7 @@ def construct_parameter_pattern(parameter):
     repeated = '[^/]'
 
     if type == 'integer':
-        repeated = '\d'
+        repeated = r'\d'
 
     return "(?P<{name}>{repeated}+)".format(name=name, repeated=repeated)
 


### PR DESCRIPTION
Fixes the following:

```
❯ flake8 | rg escape
./flex/paths.py:21:7: W605 invalid escape sequence '\.'
./flex/paths.py:21:13: W605 invalid escape sequence '\.'
./flex/paths.py:22:7: W605 invalid escape sequence '\{'
./flex/paths.py:22:13: W605 invalid escape sequence '\{'
./flex/paths.py:23:7: W605 invalid escape sequence '\}'
./flex/paths.py:23:13: W605 invalid escape sequence '\}'
./flex/paths.py:42:32: W605 invalid escape sequence '\{'
./flex/paths.py:42:36: W605 invalid escape sequence '\}'
./flex/paths.py:56:21: W605 invalid escape sequence '\d'
./flex/loading/common/mimetypes.py:26:11: W605 invalid escape sequence '\.'
./flex/loading/common/mimetypes.py:26:28: W605 invalid escape sequence '\.'
./flex/loading/common/mimetypes.py:29:7: W605 invalid escape sequence '\+'
./flex/loading/common/mimetypes.py:30:29: W605 invalid escape sequence '\.'
./flex/loading/common/mimetypes.py:30:53: W605 invalid escape sequence '\.'
./flex/loading/schema/host.py:50:36: W605 invalid escape sequence '\d'
```

These also show up as deprecation warnings when running pytest