### PR TITLE
Add setuptools as dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ requests>=2.4.3
 strict-rfc3339>=0.7
 click>=3.3
 jsonpointer==1.7
+setuptools>=44.0.0

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         "strict-rfc3339>=0.7",
         "click>=3.3",
         "jsonpointer>=1.7",
+        "setuptools>=44.0.0",
     ],
     license="BSD",
     zip_safe=False,


### PR DESCRIPTION
The pkg_resources module in python3 is provided by the setuptools
package which is therefore a dependency of flex.

Closes: #231 